### PR TITLE
nav_graph.xml関連のネーミングを修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -67,7 +67,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
     fun gotoRepositoryFragment(repositoryInfo: RepositoryInfo) {
         val action =
             RepositorySearchFragmentDirections
-                .actionRepositoriesFragmentToRepositoryFragment(
+                .actionRepositorySearchToRepositoryInfo(
                     repositoryInfo = repositoryInfo,
                 )
         findNavController().navigate(action)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -39,7 +39,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
             CustomAdapter(
                 object : CustomAdapter.OnItemClickListener {
                     override fun itemClick(repositoryInfo: RepositoryInfo) {
-                        gotoRepositoryFragment(repositoryInfo)
+                        navigateRepositoryInfoFragment(repositoryInfo)
                     }
                 },
             )
@@ -64,10 +64,10 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
         }
     }
 
-    fun gotoRepositoryFragment(repositoryInfo: RepositoryInfo) {
+    fun navigateRepositoryInfoFragment(repositoryInfo: RepositoryInfo) {
         val action =
             RepositorySearchFragmentDirections
-                .actionRepositorySearchToRepositoryInfo(
+                .actionRepositorySearchFragmentToRepositoryInfoFragment(
                     repositoryInfo = repositoryInfo,
                 )
         findNavController().navigate(action)

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -8,7 +8,7 @@
     <fragment
         android:id="@+id/oneFragment"
         android:name="jp.co.yumemi.android.code_check.RepositorySearchFragment"
-        android:label="@string/app_name"
+        android:label="@string/repositories_search"
         tools:layout="@layout/fragment_repository_search">
         <action
             android:id="@+id/action_repositoriesFragment_to_repositoryFragment"
@@ -18,7 +18,7 @@
     <fragment
         android:id="@+id/twoFragment"
         android:name="jp.co.yumemi.android.code_check.RepositoryInfoFragment"
-        android:label="@string/app_name"
+        android:label="@string/repository_info"
         tools:layout="@layout/fragment_repository_info">
         <argument
             android:name="repositoryInfo"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,20 +3,20 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/apk/res-auto"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/oneFragment">
+    app:startDestination="@id/repositorySearchFragment">
 
     <fragment
-        android:id="@+id/oneFragment"
+        android:id="@+id/repositorySearchFragment"
         android:name="jp.co.yumemi.android.code_check.RepositorySearchFragment"
         android:label="@string/repositories_search"
         tools:layout="@layout/fragment_repository_search">
         <action
             android:id="@+id/action_repositoriesFragment_to_repositoryFragment"
-            app:destination="@id/twoFragment" />
+            app:destination="@id/repositoryInfoFragment" />
     </fragment>
 
     <fragment
-        android:id="@+id/twoFragment"
+        android:id="@+id/repositoryInfoFragment"
         android:name="jp.co.yumemi.android.code_check.RepositoryInfoFragment"
         android:label="@string/repository_info"
         tools:layout="@layout/fragment_repository_info">

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -11,7 +11,7 @@
         android:label="@string/repositories_search"
         tools:layout="@layout/fragment_repository_search">
         <action
-            android:id="@+id/action_repositoriesFragment_to_repositoryFragment"
+            android:id="@+id/action_repositorySearch_to_repositoryInfo"
             app:destination="@id/repositoryInfoFragment" />
     </fragment>
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -11,7 +11,7 @@
         android:label="@string/repositories_search"
         tools:layout="@layout/fragment_repository_search">
         <action
-            android:id="@+id/action_repositorySearch_to_repositoryInfo"
+            android:id="@+id/action_repositorySearchFragment_to_repositoryInfoFragment"
             app:destination="@id/repositoryInfoFragment" />
     </fragment>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">Android Engineer CodeCheck</string>
+    <string name="repositories_search">レポジトリ検索</string>
+    <string name="repository_info">レポジトリ情報</string>
     <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
     <string name="written_language">Written in %s</string>
 </resources>


### PR DESCRIPTION
## 概要
nav_graph.xmlの下記を修正
- fragment id
- action id
- label
それに伴い `RepositorySearchFragment#gotoRepositoryFragment `を `navigateRepositoryInfoFragment`に修正

## 工夫した箇所
`action_repositorySearchFragment_to_repositoryInfoFragment`は`action_repositorySearch_to_repositoryInfo`でも良かったが、dialogなども考慮するとFragmentをつけた方が直感的になると思い冗長な名前にした。

## 動作確認
- レポジトリ検索からレポジトリ情報に遷移できることを確認
