### PR TITLE
可読性を高めるためのリファクタリング

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -8,7 +8,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
@@ -33,7 +32,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
      * - RecyclerView のセットアップ
      * - 検索ボタンタップ時の挙動の設定
      *
-     * @param view View
+     * @param view
      * @param savedInstanceState 保存されたインスタンスの状態
      */
     override fun onViewCreated(
@@ -58,7 +57,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
                 if (action == EditorInfo.IME_ACTION_SEARCH) {
                     editText.text.toString().let {
                         // IMEの検索ボタンが押されたときに、Githubのレポジトリを検索
-                        // 結果をRecyclerViewに表示する
+                        // 結果をAdapterにセットする
                         viewModel.searchRepository(it).apply {
                             adapter.submitList(this)
                         }
@@ -79,12 +78,12 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
      * リポジトリ情報画面に遷移する
      * @param repositoryInfoItem ユーザーによって選択されたリポジトリの情報
      */
-    fun navigateRepositoryInfoFragment(repositoryInfoItem: RepositoryInfoItem) {
-        val action =
-            RepositorySearchFragmentDirections
-                .actionRepositorySearchFragmentToRepositoryInfoFragment(
-                    repositoryInfoItem = repositoryInfoItem,
-                )
+    private fun navigateRepositoryInfoFragment(repositoryInfoItem: RepositoryInfoItem) {
+        val action = RepositorySearchFragmentDirections
+            .actionRepositorySearchFragmentToRepositoryInfoFragment(
+                repositoryInfoItem = repositoryInfoItem,
+            )
+
         findNavController().navigate(action)
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -51,8 +51,8 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
             DividerItemDecoration(context!!, layoutManager.orientation)
 
         val adapter =
-            CustomAdapter(
-                object : CustomAdapter.OnItemClickListener {
+            RepositoryInfoAdapter(
+                object : RepositoryInfoAdapter.OnItemClickListener {
                     override fun itemClick(repositoryInfoItem: RepositoryInfoItem) {
                         navigateRepositoryInfoFragment(repositoryInfoItem)
                     }
@@ -125,13 +125,11 @@ val diffUtil =
     }
 
 /**
- * FIXME: クラス名が抽象的なため、適切な名前に変更する
- *
  * リポジトリ情報をRecyclerViewに表示するためのアダプター
  */
-class CustomAdapter(
+class RepositoryInfoAdapter(
     private val itemClickListener: OnItemClickListener,
-) : ListAdapter<RepositoryInfoItem, CustomAdapter.ViewHolder>(diffUtil) {
+) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(diffUtil) {
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view)
 
     interface OnItemClickListener {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -79,10 +79,11 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
      * @param repositoryInfoItem ユーザーによって選択されたリポジトリの情報
      */
     private fun navigateRepositoryInfoFragment(repositoryInfoItem: RepositoryInfoItem) {
-        val action = RepositorySearchFragmentDirections
-            .actionRepositorySearchFragmentToRepositoryInfoFragment(
-                repositoryInfoItem = repositoryInfoItem,
-            )
+        val action =
+            RepositorySearchFragmentDirections
+                .actionRepositorySearchFragmentToRepositoryInfoFragment(
+                    repositoryInfoItem = repositoryInfoItem,
+                )
 
         findNavController().navigate(action)
     }
@@ -92,7 +93,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
  * リポジトリ情報をRecyclerViewに表示するためのアダプター
  */
 class RepositoryInfoAdapter(
-    private val itemClickListener: (RepositoryInfoItem) -> Unit
+    private val itemClickListener: (RepositoryInfoItem) -> Unit,
 ) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
     // region inner class, objectの定義
     class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
@@ -131,18 +132,23 @@ class RepositoryInfoAdapter(
     // endregion
 
     // region override methods
+
     /**
      * ViewHolderが生成された際に呼び出される
      *
      * @param parent 親のView
      * @param viewType Viewの種別, ここでは1つしかないので未使用
      */
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val binding = LayoutItemBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            false
-        )
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): ViewHolder {
+        val binding =
+            LayoutItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false,
+            )
         return ViewHolder(binding)
     }
 
@@ -152,7 +158,10 @@ class RepositoryInfoAdapter(
      * @param holder ViewHolder
      * @param position リストの位置
      */
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    override fun onBindViewHolder(
+        holder: ViewHolder,
+        position: Int,
+    ) {
         val item = getItem(position)
         holder.binding.repositoryNameView.text = item.name
         holder.itemView.setOnClickListener {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -51,14 +51,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
         val dividerItemDecoration =
             DividerItemDecoration(context!!, layoutManager.orientation)
 
-        val adapter =
-            RepositoryInfoAdapter(
-                object : RepositoryInfoAdapter.OnItemClickListener {
-                    override fun itemClick(repositoryInfoItem: RepositoryInfoItem) {
-                        navigateRepositoryInfoFragment(repositoryInfoItem)
-                    }
-                },
-            )
+        val adapter = RepositoryInfoAdapter { navigateRepositoryInfoFragment(it) }
 
         binding.searchInputText
             .setOnEditorActionListener { editText, action, _ ->
@@ -96,12 +89,22 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
     }
 }
 
+/**
+ * リポジトリ情報をRecyclerViewに表示するためのアダプター
+ */
+class RepositoryInfoAdapter(
+    private val itemClickListener: (RepositoryInfoItem) -> Unit
+) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
+    // region inner class, objectの定義
+    class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
 
-// RecyclerViewのアイテムの差分を計算し、 必要なアップデートのみを行うようにするためのCallback
-val diffUtil =
-    object : DiffUtil.ItemCallback<RepositoryInfoItem>() {
+    /**
+     * RecyclerViewのアイテムの差分を計算し、 必要なアップデートのみを行うようにするためのCallback
+     */
+    object DiffCallback : DiffUtil.ItemCallback<RepositoryInfoItem>() {
         /**
          * 名前を比較し、二つのアイテムが同一のアイテムを表しているかどうかを判断する
+         *
          * @param oldItem 古いリポジトリ情報
          * @param newItem 新しいリポジトリ情報
          */
@@ -114,6 +117,7 @@ val diffUtil =
 
         /**
          * 二つのアイテムのデータ内容が等しいかどうかを判断する
+         *
          * @param oldItem 古いリポジトリ情報
          * @param newItem 新しいリポジトリ情報
          */
@@ -125,19 +129,9 @@ val diffUtil =
         }
     }
 
-/**
- * リポジトリ情報をRecyclerViewに表示するためのアダプター
- */
-class RepositoryInfoAdapter(
-    private val itemClickListener: OnItemClickListener,
-) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(diffUtil) {
-    class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
+    // endregion
 
-
-    interface OnItemClickListener {
-        fun itemClick(repositoryInfoItem: RepositoryInfoItem)
-    }
-
+    // region override methods
     /**
      * ViewHolderが生成された際に呼び出される
      *
@@ -163,7 +157,8 @@ class RepositoryInfoAdapter(
         val item = getItem(position)
         holder.binding.repositoryNameView.text = item.name
         holder.itemView.setOnClickListener {
-            itemClickListener.itemClick(item)
+            itemClickListener(item)
         }
     }
+    // endregion
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -83,7 +83,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
 
     /**
      * リポジトリ情報画面に遷移する
-     * @param repositoryInfoItem 検索したレポジトリの情報
+     * @param repositoryInfoItem ユーザーによって選択されたリポジトリの情報
      */
     fun navigateRepositoryInfoFragment(repositoryInfoItem: RepositoryInfoItem) {
         val action =

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositorySearchBinding
+import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
 
 /**
  * リポジトリ検索画面
@@ -130,7 +131,8 @@ val diffUtil =
 class RepositoryInfoAdapter(
     private val itemClickListener: OnItemClickListener,
 ) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(diffUtil) {
-    class ViewHolder(view: View) : RecyclerView.ViewHolder(view)
+    class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
+
 
     interface OnItemClickListener {
         fun itemClick(repositoryInfoItem: RepositoryInfoItem)
@@ -142,14 +144,13 @@ class RepositoryInfoAdapter(
      * @param parent 親のView
      * @param viewType Viewの種別, ここでは1つしかないので未使用
      */
-    override fun onCreateViewHolder(
-        parent: ViewGroup,
-        viewType: Int,
-    ): ViewHolder {
-        val view =
-            LayoutInflater.from(parent.context)
-                .inflate(R.layout.layout_item, parent, false)
-        return ViewHolder(view)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = LayoutItemBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return ViewHolder(binding)
     }
 
     /**
@@ -158,14 +159,9 @@ class RepositoryInfoAdapter(
      * @param holder ViewHolder
      * @param position リストの位置
      */
-    override fun onBindViewHolder(
-        holder: ViewHolder,
-        position: Int,
-    ) {
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = getItem(position)
-        (holder.itemView.findViewById<View>(R.id.repositoryNameView) as TextView).text =
-            item.name
-
+        holder.binding.repositoryNameView.text = item.name
         holder.itemView.setOnClickListener {
             itemClickListener.itemClick(item)
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -50,7 +50,7 @@ class RepositorySearchViewModel(
 
                 val repositoryInfoItemList = mutableListOf<RepositoryInfoItem>()
 
-                 // アイテムの個数分ループし、JsonをパースしてRepositoryInfoのリストを作成する
+                // アイテムの個数分ループし、JsonをパースしてRepositoryInfoのリストを作成する
                 for (i in 0 until jsonItems.length()) {
                     val jsonItem = jsonItems.optJSONObject(i)!!
                     val name = jsonItem.optString("full_name")


### PR DESCRIPTION
## 概要
- CustomAdapter -> RepositoryInfoAdapterに
- RepositoryInfoAdapterで ViewBindingを使用するように修正
- RepositoryInfoAdapterのリファクタリング
    - diffUtilをinner objectに
    - Listenerをラムダで受け取るように
    - それに伴いnavigateRepositoryInfoFragmentをpublicにする必要がなくなったため privateに