### PR TITLE
非null表明演算子を除去

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
@@ -23,7 +23,6 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
     private val args: RepositoryInfoFragmentArgs by navArgs()
 
     private var binding: FragmentRepositoryInfoBinding? = null
-    private val _binding get() = binding!!
 
     /**
      * FragmentのViewが生成された後に呼び出される。
@@ -44,12 +43,14 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
 
         val repositoryInfo = args.repositoryInfoItem
 
-        _binding.ownerIconView.load(repositoryInfo.ownerIconUrl)
-        _binding.nameView.text = repositoryInfo.name
-        _binding.languageView.text = repositoryInfo.language
-        _binding.starsView.text = "${repositoryInfo.stargazersCount} stars"
-        _binding.watchersView.text = "${repositoryInfo.watchersCount} watchers"
-        _binding.forksView.text = "${repositoryInfo.forksCount} forks"
-        _binding.openIssuesView.text = "${repositoryInfo.openIssuesCount} open issues"
+        binding?.apply {
+            ownerIconView.load(repositoryInfo.ownerIconUrl)
+            nameView.text = repositoryInfo.name
+            languageView.text = repositoryInfo.language
+            starsView.text = "${repositoryInfo.stargazersCount} stars"
+            watchersView.text = "${repositoryInfo.watchersCount} watchers"
+            forksView.text = "${repositoryInfo.forksCount} forks"
+            openIssuesView.text = "${repositoryInfo.openIssuesCount} open issues"
+        }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
@@ -44,7 +44,10 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
         val repositoryInfo = args.repositoryInfoItem
 
         binding?.apply {
-            ownerIconView.load(repositoryInfo.ownerIconUrl)
+            ownerIconView.load(repositoryInfo.ownerIconUrl) {
+                placeholder(R.drawable.ic_android)
+                error(R.drawable.ic_android)
+            }
             nameView.text = repositoryInfo.name
             languageView.text = repositoryInfo.language
             starsView.text = "${repositoryInfo.stargazersCount} stars"

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -43,12 +43,14 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
 
         val binding = FragmentRepositorySearchBinding.bind(view)
 
-        val viewModel = RepositorySearchViewModel(context!!)
+        val context = requireContext()
 
-        val layoutManager = LinearLayoutManager(context!!)
+        val viewModel = RepositorySearchViewModel(context)
+
+        val layoutManager = LinearLayoutManager(context)
 
         val dividerItemDecoration =
-            DividerItemDecoration(context!!, layoutManager.orientation)
+            DividerItemDecoration(context, layoutManager.orientation)
 
         val adapter = RepositoryInfoAdapter { navigateRepositoryInfoFragment(it) }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -8,7 +8,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -73,6 +75,26 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
             it.layoutManager = layoutManager
             it.addItemDecoration(dividerItemDecoration)
             it.adapter = adapter
+        }
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.errorState.collect {
+                when (it) {
+                    ErrorState.Idle -> {
+                        // 何もしない
+                    }
+                    ErrorState.CantFetchRepositoryInfo -> {
+                        // alert dialogを表示する
+                        AlertDialog.Builder(context)
+                            .setTitle(R.string.error_dialog_title)
+                            .setMessage(R.string.error_dialog_message)
+                            .setPositiveButton(R.string.error_dialog_positive_button) { _, _ ->
+                                viewModel.clearErrorState()
+                            }
+                            .show()
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -5,6 +5,7 @@ package jp.co.yumemi.android.code_check
 
 import android.content.Context
 import android.os.Parcelable
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.call.receive
@@ -16,6 +17,8 @@ import io.ktor.client.statement.HttpResponse
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
@@ -27,6 +30,13 @@ import java.util.Date
 class RepositorySearchViewModel(
     val context: Context,
 ) : ViewModel() {
+    companion object {
+        private const val TAG = "RepositorySearchViewModel"
+    }
+
+    private val _errorState: MutableStateFlow<ErrorState> = MutableStateFlow(ErrorState.Idle)
+    val errorState = _errorState.asStateFlow()
+
     /**
      * inputTextを元にリポジトリを検索する
      *
@@ -46,25 +56,32 @@ class RepositorySearchViewModel(
 
                 val jsonBody = JSONObject(response.receive<String>())
 
-                val jsonItems = jsonBody.optJSONArray("items")!!
+                val jsonItems = jsonBody.optJSONArray("items")
+
+                if (jsonItems == null) {
+                    _errorState.value = ErrorState.CantFetchRepositoryInfo
+                    Log.d(TAG, "jsonItems is null, inputText: $inputText")
+                    return@async listOf<RepositoryInfoItem>()
+                }
 
                 val repositoryInfoItemList = mutableListOf<RepositoryInfoItem>()
 
                 // アイテムの個数分ループし、JsonをパースしてRepositoryInfoのリストを作成する
                 for (i in 0 until jsonItems.length()) {
-                    val jsonItem = jsonItems.optJSONObject(i)!!
+                    val jsonItem = jsonItems.optJSONObject(i)
                     val name = jsonItem.optString("full_name")
-                    val ownerIconUrl = jsonItem.optJSONObject("owner")!!.optString("avatar_url")
+                    val ownerIconUrl = jsonItem.optJSONObject("owner")?.optString("avatar_url")
                     val language = jsonItem.optString("language")
                     val stargazersCount = jsonItem.optLong("stargazers_count")
                     val watchersCount = jsonItem.optLong("watchers_count")
-                    val forksCount = jsonItem.optLong("forks_conut")
+                    val forksCount = jsonItem.optLong("forks_count")
                     val openIssuesCount = jsonItem.optLong("open_issues_count")
 
                     repositoryInfoItemList.add(
                         RepositoryInfoItem(
                             name = name,
-                            ownerIconUrl = ownerIconUrl,
+                            ownerIconUrl = ownerIconUrl ?: "",
+                            // FIXME: ここでcontextから文字列を生成するべきではないため、Fragmentでするように修正する必要がある
                             language = context.getString(R.string.written_language, language),
                             stargazersCount = stargazersCount,
                             watchersCount = watchersCount,
@@ -79,6 +96,10 @@ class RepositorySearchViewModel(
                 return@async repositoryInfoItemList.toList()
             }.await()
         }
+
+    fun clearErrorState() {
+        _errorState.value = ErrorState.Idle
+    }
 }
 
 /**
@@ -94,3 +115,8 @@ data class RepositoryInfoItem(
     val forksCount: Long,
     val openIssuesCount: Long,
 ) : Parcelable
+
+sealed interface ErrorState {
+    object Idle : ErrorState
+    object CantFetchRepositoryInfo : ErrorState
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -116,6 +116,9 @@ data class RepositoryInfoItem(
     val openIssuesCount: Long,
 ) : Parcelable
 
+/**
+ * エラーの状態を表すsealed interface
+ */
 sealed interface ErrorState {
     object Idle : ErrorState
     object CantFetchRepositoryInfo : ErrorState

--- a/app/src/main/res/drawable/ic_android.xml
+++ b/app/src/main/res/drawable/ic_android.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+        
+    <path android:fillColor="@android:color/white" android:pathData="M17.6,11.48 L19.44,8.3a0.63,0.63 0,0 0,-1.09 -0.63l-1.88,3.24a11.43,11.43 0,0 0,-8.94 0L5.65,7.67a0.63,0.63 0,0 0,-1.09 0.63L6.4,11.48A10.81,10.81 0,0 0,1 20L23,20A10.81,10.81 0,0 0,17.6 11.48ZM7,17.25A1.25,1.25 0,1 1,8.25 16,1.25 1.25,0 0,1 7,17.25ZM17,17.25A1.25,1.25 0,1 1,18.25 16,1.25 1.25,0 0,1 17,17.25Z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="repository_info">レポジトリ情報</string>
     <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
     <string name="written_language">Written in %s</string>
+
+    <string name="error_dialog_title">レポジトリ情報の取得に失敗しました</string>
+    ¥<string name="error_dialog_message">時間をおいて再度実行するか、アプリを最新にアップデートしてください。\n解消されない場合はお手数ですが開発者へお問い合わせください</string>
+    <string name="error_dialog_positive_button">OK</string>
 </resources>


### PR DESCRIPTION
## 概要
- RepositoryInfoFragment.kt
  - バインディング処理を ?.applyで行うように修正
    - nullの場合、ユーザーが困惑する可能性はあるが、bindingがnullになる可能性は比較的低いはず
    - 今回はエラーハンドリングは省略した
  - 上記にともないBacking propertyが不要になったため除去
  - ownerIconUrlが""の場合 プレースホルダーアイコンを表示するように修正
- RepositorySearchFragment.kt
  - contextを`reuquireContext()`を使用するように修正
  - ErrorStateによってダイアログを表示するように修正
- RepositorySearchViewModel.kt
  - エラー状態を表すsealed interfaceを追加
  - エラー状態を保持するFlowを追加
  - jsonItemsがnullの場合はErrorState
  - forks_conut -> forks_countに修正

## 工夫した箇所
- jsonItemsがnullの場合はエラーダイアログを表示するように
  - 経緯
    - `?.let`で書いても良かったのだが、エラーの場合ユーザーが困惑する可能性がある
    - ここで追加しなくてもいいかなと思ったが、採点ポイントの記事で言及されていたはず
- sealed interface の `ErrorState`を作り他のエラーパターンが出た場合の修正を用意に
## 動作確認
### 正常系
既存の振る舞いを破壊していないことを確認。
エビデンスは無し

### エラーケース
- if文をtrueになるようにして確認した

[エラーケース.webm](https://github.com/Ren-Toyokawa/android-engineer-codecheck/assets/23397943/a75a9a74-efe6-452d-afd9-307c14fd640c)
