### PR TITLE
nullハンドリングとlateinitの除去

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -11,9 +11,10 @@ import java.util.Date
  * このアクティビティが本アプリのエントリーポイントとなる
  */
 class MainActivity : AppCompatActivity(R.layout.activity_main) {
+    // FIXME: Jetpack Datastoreなどを使用した方が良い気がする。
     companion object {
         // 最後に検索した日時
         // 検索を実行した際に、この変数に現在時刻を代入する
-        lateinit var lastSearchDate: Date
+        var lastSearchDate: Date? = null
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -68,17 +68,17 @@ class RepositorySearchViewModel(
 
                 // アイテムの個数分ループし、JsonをパースしてRepositoryInfoのリストを作成する
                 for (i in 0 until jsonItems.length()) {
-                    val jsonItem = jsonItems.optJSONObject(i)
-                    val name = jsonItem.optString("full_name")
-                    val ownerIconUrl = jsonItem.optJSONObject("owner")?.optString("avatar_url")
-                    val language = jsonItem.optString("language")
-                    val stargazersCount = jsonItem.optLong("stargazers_count")
-                    val watchersCount = jsonItem.optLong("watchers_count")
-                    val forksCount = jsonItem.optLong("forks_count")
-                    val openIssuesCount = jsonItem.optLong("open_issues_count")
+                    try {
+                        val jsonItem = jsonItems.getJSONObject(i)
+                        val name = jsonItem.getString("full_name")
+                        val ownerIconUrl = jsonItem.getJSONObject("owner").optString("avatar_url")
+                        val language = jsonItem.optString("language") ?: null
+                        val stargazersCount = jsonItem.getLong("stargazers_count")
+                        val watchersCount = jsonItem.getLong("watchers_count")
+                        val forksCount = jsonItem.getLong("forks_count")
+                        val openIssuesCount = jsonItem.getLong("open_issues_count")
 
-                    repositoryInfoItemList.add(
-                        RepositoryInfoItem(
+                        val repositoryInfoItem = RepositoryInfoItem(
                             name = name,
                             ownerIconUrl = ownerIconUrl ?: "",
                             // FIXME: ここでcontextから文字列を生成するべきではないため、Fragmentでするように修正する必要がある
@@ -87,8 +87,13 @@ class RepositorySearchViewModel(
                             watchersCount = watchersCount,
                             forksCount = forksCount,
                             openIssuesCount = openIssuesCount,
-                        ),
-                    )
+                        )
+
+                        repositoryInfoItemList.add(repositoryInfoItem)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "error: $e")
+                        _errorState.value = ErrorState.CantFetchRepositoryInfo
+                    }
                 }
 
                 lastSearchDate = Date()
@@ -109,7 +114,7 @@ class RepositorySearchViewModel(
 data class RepositoryInfoItem(
     val name: String,
     val ownerIconUrl: String,
-    val language: String,
+    val language: String?,
     val stargazersCount: Long,
     val watchersCount: Long,
     val forksCount: Long,


### PR DESCRIPTION
## 概要
- MainActivity
  - lateinit をやめて nullableにするように修正
- RepositorySearchViewModel.kt
  -  optXXXをやめてgetXXXを使用するように修正
  - Response Schemaを確認したところlanguageは初期値がnullのため optXXXを使用
      - https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-repositories
  - もしgetXXXでエラーとなった場合 エラーダイアログを表示するように

## 工夫した箇所
- getXXXを使用するようにした箇所
- もしそこで例外が出るようであればAPIのスキーマが更新されている可能性が高い
- 誤ったkeyを指定していた場合も気がつきやすい
- といった理由でエラーダイアログを表示するように。
- もし Firebaseが使えるのであればクラッシュログを出させた方が良い。

## 動作確認
### 正常系
既存の振る舞いを破壊していないことを確認

### 異常系
誤ったkeyを指定して動作を確認
[エラー_jsonのkeyが存在しない場合.webm](https://github.com/Ren-Toyokawa/android-engineer-codecheck/assets/23397943/25b5c9a0-1175-42f0-bfeb-99c48b6599b4)


