### PR TITLE
Jsonのパースとネットワークのエラーハンドリングを追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'kotlin-parcelize'
     id 'androidx.navigation.safeargs.kotlin'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.21'
 }
 
 android {
@@ -55,6 +56,10 @@ dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
     implementation 'io.ktor:ktor-client-android:1.6.4'
+    implementation 'io.ktor:ktor-client-serialization-jvm:1.6.4'
+    implementation 'io.ktor:ktor-client-serialization-jvm:1.6.4'
+
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3'
 
     implementation 'io.coil-kt:coil:1.3.2'
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
@@ -52,7 +52,7 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
         val repositoryInfo = args.repositoryInfoItem
 
         binding?.apply {
-            ownerIconView.load(repositoryInfo.ownerIconUrl) {
+            ownerIconView.load(repositoryInfo.owner.avatarUrl) {
                 placeholder(R.drawable.ic_android)
                 error(R.drawable.ic_android)
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -89,11 +89,20 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
                         // 何もしない
                     }
                     ErrorState.CantFetchRepositoryInfo -> {
-                        // alert dialogを表示する
                         AlertDialog.Builder(context)
                             .setTitle(R.string.error_dialog_title)
                             .setMessage(R.string.error_dialog_message)
                             .setPositiveButton(R.string.error_dialog_positive_button) { _, _ ->
+                                viewModel.clearErrorState()
+                            }
+                            .show()
+                    }
+
+                    ErrorState.NetworkError -> {
+                        AlertDialog.Builder(context)
+                            .setTitle(R.string.network_error_dialog_title)
+                            .setMessage(R.string.network_error_dialog_message)
+                            .setPositiveButton(R.string.network_error_dialog_positive_button) { _, _ ->
                                 viewModel.clearErrorState()
                             }
                             .show()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -81,6 +81,9 @@ class RepositorySearchViewModel : ViewModel() {
             } catch (e: SerializationException) {
                 Log.e(TAG, "error: $e")
                 _errorState.value = ErrorState.CantFetchRepositoryInfo
+            } catch (e: IOException) {
+                Log.e(TAG, "error: $e")
+                _errorState.value = ErrorState.NetworkError
             }
 
             lastSearchDate = Date()
@@ -136,4 +139,6 @@ sealed interface ErrorState {
     object Idle : ErrorState
 
     object CantFetchRepositoryInfo : ErrorState
+
+    object NetworkError : ErrorState
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,10 @@
     <string name="language_not_specified">言語は設定されていません</string>
 
     <string name="error_dialog_title">レポジトリ情報の取得に失敗しました</string>
-    ¥<string name="error_dialog_message">時間をおいて再度実行するか、アプリを最新にアップデートしてください。\n解消されない場合はお手数ですが開発者へお問い合わせください</string>
+    <string name="error_dialog_message">時間をおいて再度実行するか、アプリを最新にアップデートしてください。\n解消されない場合はお手数ですが開発者へお問い合わせください</string>
     <string name="error_dialog_positive_button">OK</string>
+
+    <string name="network_error_dialog_title">ネットワークエラー</string>
+    <string name="network_error_dialog_message">ネットワークに接続されていません。WIFIの接続などネットワーク接続を確認してください。</string>
+    <string name="network_error_dialog_positive_button">OK</string>
 </resources>


### PR DESCRIPTION
## 概要
- Jsonの Parse を Ktor と Kotlin Serializationで行うように修正
- Serializationのエラーハンドリングを追加
- ネットワークエラーのハンドリングを追加

## 工夫
- Serializationエラーはユーザーが解決できない可能性が比較的高いため、開発者に問い合わせをする可能性も示唆している
- NetworkはWifi由来の可能性があるのでそれをダイアログで表示

## 動作確認
### 正常系
[正常系.webm](https://github.com/Ren-Toyokawa/android-engineer-codecheck/assets/23397943/0d94a3e9-80cc-4e04-8bba-885fb958c198)

### 異常系(パースエラー)
<img src="https://github.com/Ren-Toyokawa/android-engineer-codecheck/assets/23397943/836f65cf-ba57-420a-81ab-a662097ee4eb" width="300">

### 異常系(ネットワーク)
https://github.com/Ren-Toyokawa/android-engineer-codecheck/assets/23397943/daa0c931-9659-4f6e-88b4-17506f56ba8a


