### PR TITLE
Fat Fragmentのリファクタリング

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoAdapter.kt
@@ -1,0 +1,90 @@
+package jp.co.yumemi.android.code_check
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
+
+/**
+ * リポジトリ情報をRecyclerViewに表示するためのアダプター
+ */
+class RepositoryInfoAdapter(
+    private val itemClickListener: (RepositoryInfoItem) -> Unit,
+) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
+    // region inner class, objectの定義
+    class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
+
+    /**
+     * RecyclerViewのアイテムの差分を計算し、 必要なアップデートのみを行うようにするためのCallback
+     */
+    object DiffCallback : DiffUtil.ItemCallback<RepositoryInfoItem>() {
+        /**
+         * 名前を比較し、二つのアイテムが同一のアイテムを表しているかどうかを判断する
+         *
+         * @param oldItem 古いリポジトリ情報
+         * @param newItem 新しいリポジトリ情報
+         */
+        override fun areItemsTheSame(
+            oldItem: RepositoryInfoItem,
+            newItem: RepositoryInfoItem,
+        ): Boolean {
+            return oldItem.name == newItem.name
+        }
+
+        /**
+         * 二つのアイテムのデータ内容が等しいかどうかを判断する
+         *
+         * @param oldItem 古いリポジトリ情報
+         * @param newItem 新しいリポジトリ情報
+         */
+        override fun areContentsTheSame(
+            oldItem: RepositoryInfoItem,
+            newItem: RepositoryInfoItem,
+        ): Boolean {
+            return oldItem == newItem
+        }
+    }
+
+    // endregion
+
+    // region override methods
+
+    /**
+     * ViewHolderが生成された際に呼び出される
+     *
+     * @param parent 親のView
+     * @param viewType Viewの種別, ここでは1つしかないので未使用
+     */
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): ViewHolder {
+        val binding =
+            LayoutItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false,
+            )
+        return ViewHolder(binding)
+    }
+
+    /**
+     * ViewHolderにデータをバインドする
+     *
+     * @param holder ViewHolder
+     * @param position リストの位置
+     */
+    override fun onBindViewHolder(
+        holder: ViewHolder,
+        position: Int,
+    ) {
+        val item = getItem(position)
+        holder.binding.repositoryNameView.text = item.name
+        holder.itemView.setOnClickListener {
+            itemClickListener(item)
+        }
+    }
+    // endregion
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -3,6 +3,7 @@
  */
 package jp.co.yumemi.android.code_check
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -10,6 +11,7 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DiffUtil
@@ -19,13 +21,18 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositorySearchBinding
 import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 /**
  * リポジトリ検索画面
  * 画面上部のテキストフィールドに入力された文字列を元に、Githubのレポジトリを検索する
  */
 class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
+    private var binding: FragmentRepositorySearchBinding? = null
+
+    private val viewModel: RepositorySearchViewModel by viewModels()
+
     /**
      * Viewが生成された後に呼び出される
      *
@@ -44,72 +51,108 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        val binding = FragmentRepositorySearchBinding.bind(view)
+        binding = FragmentRepositorySearchBinding.bind(view)
 
+        setupRecyclerView()
+        setupSearchInput()
+        applySearchResult()
+        errorHandling()
+    }
+
+    /**
+     * RecyclerViewのセットアップを行う
+     */
+    private fun setupRecyclerView() {
         val context = requireContext()
-
-        val viewModel = RepositorySearchViewModel()
-
         val layoutManager = LinearLayoutManager(context)
+        val dividerItemDecoration = DividerItemDecoration(
+            context,
+            layoutManager.orientation
+        )
+        val adapter = RepositoryInfoAdapter { repositoryInfoItem ->
+            navigateRepositoryInfoFragment(repositoryInfoItem)
+        }
 
-        val dividerItemDecoration =
-            DividerItemDecoration(context, layoutManager.orientation)
+        binding?.apply {
+            recyclerView.layoutManager = layoutManager
+            recyclerView.addItemDecoration(dividerItemDecoration)
+            recyclerView.adapter = adapter
+        }
+    }
 
-        val adapter = RepositoryInfoAdapter { navigateRepositoryInfoFragment(it) }
-
-        binding.searchInputText
-            .setOnEditorActionListener { editText, action, _ ->
-                if (action == EditorInfo.IME_ACTION_SEARCH) {
-                    editText.text.toString().let {
-                        // IMEの検索ボタンが押されたときに、Githubのレポジトリを検索
-                        // 結果をAdapterにセットする
-                        viewModel.searchRepository(it)
-                    }
-                    return@setOnEditorActionListener true
+    /**
+     * 検索ボタンがタップされた際の挙動を設定する
+     */
+    private fun setupSearchInput() {
+        binding?.apply {
+            searchInputText.setOnEditorActionListener { editText, actionId, _ ->
+                if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                    viewModel.searchRepository(editText.text.toString())
+                    true
+                } else {
+                    false
                 }
-                return@setOnEditorActionListener false
-            }
-
-        lifecycleScope.launchWhenStarted {
-            viewModel.searchResults.collectLatest {
-                adapter.submitList(it)
             }
         }
+    }
 
-        binding.recyclerView.also {
-            it.layoutManager = layoutManager
-            it.addItemDecoration(dividerItemDecoration)
-            it.adapter = adapter
-        }
+    /**
+     * 検索結果をRecyclerViewに反映する
+     */
+    private fun applySearchResult() {
+        viewModel
+            .searchResults
+            .onEach { searchResults ->
+                val adapter = binding?.recyclerView?.adapter as? RepositoryInfoAdapter
+                // HACK: 厳密なハンドリングをするメリットが少ないためここではnullの場合はreturnする
+                adapter ?: return@onEach
 
-        lifecycleScope.launchWhenStarted {
-            viewModel.errorState.collect {
+                adapter.submitList(searchResults)
+            }
+            .launchIn(lifecycleScope)
+    }
+
+    /**
+     * エラーの状態を監視し、エラーが発生した場合にダイアログを表示する
+     */
+    private fun errorHandling() {
+        val context = requireContext()
+        viewModel
+            .errorState
+            .onEach {
                 when (it) {
-                    ErrorState.Idle -> {
-                        // 何もしない
-                    }
-                    ErrorState.CantFetchRepositoryInfo -> {
-                        AlertDialog.Builder(context)
-                            .setTitle(R.string.error_dialog_title)
-                            .setMessage(R.string.error_dialog_message)
-                            .setPositiveButton(R.string.error_dialog_positive_button) { _, _ ->
-                                viewModel.clearErrorState()
-                            }
-                            .show()
-                    }
-
-                    ErrorState.NetworkError -> {
-                        AlertDialog.Builder(context)
-                            .setTitle(R.string.network_error_dialog_title)
-                            .setMessage(R.string.network_error_dialog_message)
-                            .setPositiveButton(R.string.network_error_dialog_positive_button) { _, _ ->
-                                viewModel.clearErrorState()
-                            }
-                            .show()
-                    }
+                    ErrorState.CantFetchRepositoryInfo -> showCantFetchRepositoryInfoDialog(context)
+                    ErrorState.NetworkError -> showNetworkErrorDialog(context)
+                    ErrorState.Idle -> { /* 何もしない */ }
                 }
             }
-        }
+            .launchIn(lifecycleScope)
+    }
+
+    /**
+     * ネットワークエラーのダイアログを表示する
+     */
+    private fun showNetworkErrorDialog(context: Context) {
+        AlertDialog.Builder(context)
+            .setTitle(R.string.network_error_dialog_title)
+            .setMessage(R.string.network_error_dialog_message)
+            .setPositiveButton(R.string.network_error_dialog_positive_button) { _, _ ->
+                viewModel.clearErrorState()
+            }
+            .show()
+    }
+
+    /**
+     * リポジトリ情報の取得に失敗した場合のダイアログを表示する
+     */
+    private fun showCantFetchRepositoryInfoDialog(context: Context) {
+        AlertDialog.Builder(context)
+            .setTitle(R.string.error_dialog_title)
+            .setMessage(R.string.error_dialog_message)
+            .setPositiveButton(R.string.error_dialog_positive_button) { _, _ ->
+                viewModel.clearErrorState()
+            }
+            .show()
     }
 
     /**
@@ -124,6 +167,12 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
                 )
 
         findNavController().navigate(action)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+
     }
 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -5,22 +5,16 @@ package jp.co.yumemi.android.code_check
 
 import android.content.Context
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositorySearchBinding
-import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -174,86 +168,4 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
         binding = null
 
     }
-}
-
-/**
- * リポジトリ情報をRecyclerViewに表示するためのアダプター
- */
-class RepositoryInfoAdapter(
-    private val itemClickListener: (RepositoryInfoItem) -> Unit,
-) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
-    // region inner class, objectの定義
-    class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
-
-    /**
-     * RecyclerViewのアイテムの差分を計算し、 必要なアップデートのみを行うようにするためのCallback
-     */
-    object DiffCallback : DiffUtil.ItemCallback<RepositoryInfoItem>() {
-        /**
-         * 名前を比較し、二つのアイテムが同一のアイテムを表しているかどうかを判断する
-         *
-         * @param oldItem 古いリポジトリ情報
-         * @param newItem 新しいリポジトリ情報
-         */
-        override fun areItemsTheSame(
-            oldItem: RepositoryInfoItem,
-            newItem: RepositoryInfoItem,
-        ): Boolean {
-            return oldItem.name == newItem.name
-        }
-
-        /**
-         * 二つのアイテムのデータ内容が等しいかどうかを判断する
-         *
-         * @param oldItem 古いリポジトリ情報
-         * @param newItem 新しいリポジトリ情報
-         */
-        override fun areContentsTheSame(
-            oldItem: RepositoryInfoItem,
-            newItem: RepositoryInfoItem,
-        ): Boolean {
-            return oldItem == newItem
-        }
-    }
-
-    // endregion
-
-    // region override methods
-
-    /**
-     * ViewHolderが生成された際に呼び出される
-     *
-     * @param parent 親のView
-     * @param viewType Viewの種別, ここでは1つしかないので未使用
-     */
-    override fun onCreateViewHolder(
-        parent: ViewGroup,
-        viewType: Int,
-    ): ViewHolder {
-        val binding =
-            LayoutItemBinding.inflate(
-                LayoutInflater.from(parent.context),
-                parent,
-                false,
-            )
-        return ViewHolder(binding)
-    }
-
-    /**
-     * ViewHolderにデータをバインドする
-     *
-     * @param holder ViewHolder
-     * @param position リストの位置
-     */
-    override fun onBindViewHolder(
-        holder: ViewHolder,
-        position: Int,
-    ) {
-        val item = getItem(position)
-        holder.binding.repositoryNameView.text = item.name
-        holder.itemView.setOnClickListener {
-            itemClickListener(item)
-        }
-    }
-    // endregion
 }


### PR DESCRIPTION
## 概要
- onViewCreatedが肥大化していたので処理を個別に分割
- 検索結果をStateFlowにするのは前のissueで行なっていたため割愛
- 一つのFragmentにそこまで機能が密集していなかったため、厳密にはFat Fragmentに対する対応になっていないかもしれない

## 工夫した箇所
- flowに対して'onEach', 'launchIn'を使用し、ネストを浅く(collectだとScopeで囲う必要がある)

## 動作確認
動作が変わっていないことを確認。エビデンスは割愛