### PR TITLE
HttpClientをSingletonに

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -3,6 +3,7 @@
  */
 package jp.co.yumemi.android.code_check
 
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import java.util.Date
@@ -19,9 +20,17 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         var lastSearchDate: Date? = null
     }
 
+    /**
+     * 下記のタイミングで呼び出される
+     * 1. アプリケーションがユーザーによって終了される場合。
+     * 2. システムによってリソースの解放が必要な場合。
+     * 3. アクティビティのライフサイクルの一部として、設定変更（例: 画面の回転）や他のアクティビティへの遷移時。
+     */
     override fun onDestroy() {
         super.onDestroy()
-        // Activityが破棄される際に、HttpClientを閉じる
+
+        // アプリケーションが終了する際に、HttpClientをクローズする
+        // 画面の回転時もこの関数自体は呼ばれるため、isFinishingでユーザーがアプリを終了したかどうかを判定する
         if (isFinishing) {
             client.close()
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -4,6 +4,7 @@
 package jp.co.yumemi.android.code_check
 
 import androidx.appcompat.app.AppCompatActivity
+import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import java.util.Date
 
 /**
@@ -16,5 +17,13 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         // 最後に検索した日時
         // 検索を実行した際に、この変数に現在時刻を代入する
         var lastSearchDate: Date? = null
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Activityが破棄される際に、HttpClientを閉じる
+        if (isFinishing) {
+            client.close()
+        }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -117,9 +117,18 @@ data class Owner(
  * エラーの状態を表すsealed interface
  */
 sealed interface ErrorState {
+    /**
+     * 何もしていない状態
+     */
     object Idle : ErrorState
 
+    /**
+     * リポジトリ情報の取得に失敗した場合
+     */
     object CantFetchRepositoryInfo : ErrorState
 
+    /**
+     * ネットワークエラーが発生した場合
+     */
     object NetworkError : ErrorState
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -17,6 +17,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -36,32 +37,12 @@ class RepositorySearchViewModel : ViewModel() {
         private const val TAG = "RepositorySearchViewModel"
     }
 
-    private val client = HttpClient(Android) {
-        install(JsonFeature){
-            serializer = KotlinxSerializer(
-                json = kotlinx.serialization.json.Json {
-                    ignoreUnknownKeys = true
-                }
-            )
-        }
-    }
-
     private val _errorState: MutableStateFlow<ErrorState> = MutableStateFlow(ErrorState.Idle)
     val errorState = _errorState.asStateFlow()
 
     // StateFlowを使用して検索結果を保持
     private val _searchResults = MutableStateFlow<List<RepositoryInfoItem>>(emptyList())
     val searchResults = _searchResults.asStateFlow()
-
-    // region life cycle event
-    override fun onCleared() {
-        super.onCleared()
-        // HACK: 現状は一つのViewModelしか存在しないため、ここでclientをcloseしている
-        //       複数の画面で呼び出される場合はシングルトンにした方が良いため、必要に応じて修正する
-        client.close()
-    }
-    // endregion
-
 
     /**
      * inputTextを元にリポジトリを検索する


### PR DESCRIPTION
## 概要
- object を用いてHttpClientをシングルトンに
  - 本来はHiltなどを使うのが良いが、本来の目的から外れる気がするのでやっていない
- HttpClientのcloseをViewModelで行なっていたが、MainActivityで行うように(アプリケーションの生存時間と同じにするため)
- 追記: SingletonHttpClientのコミットが漏れていたため #29で対応した。

## 工夫したところ
- MyActivityのonDestroyで isFinishedを使用した箇所(工夫というほどではないが)
- onDestroyに呼び出されるタイミングを明示的に書いたところ

## 動作確認
通常の動作が壊れていないことを確認。
エビデンスは割愛