### PR TITLE
CQS原則に則るように修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -81,7 +81,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
         binding?.apply {
             searchInputText.setOnEditorActionListener { editText, actionId, _ ->
                 if (actionId == EditorInfo.IME_ACTION_SEARCH) {
-                    viewModel.searchRepository(editText.text.toString())
+                    viewModel.executeSearchRepository(editText.text.toString())
                     true
                 } else {
                     false


### PR DESCRIPTION
## 概要
- searchRepository -> executeRepositorySearchに(関数名がクエリっぽかったので)
- searchRepositoryを結果を返却する関数に
- エラーハンドリングを別の関数に

## 工夫した箇所
- 特になし

## 動作確認
通常の動作を破壊していないことを確認  
エビデンスは割愛