### PR TITLE
DRY原則に従うように修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -3,6 +3,7 @@
  */
 package jp.co.yumemi.android.code_check
 
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import java.util.Date
@@ -19,9 +20,17 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         var lastSearchDate: Date? = null
     }
 
+    /**
+     * 下記のタイミングで呼び出される
+     * 1. アプリケーションがユーザーによって終了される場合。
+     * 2. システムによってリソースの解放が必要な場合。
+     * 3. アクティビティのライフサイクルの一部として、設定変更（例: 画面の回転）や他のアクティビティへの遷移時。
+     */
     override fun onDestroy() {
         super.onDestroy()
-        // Activityが破棄される際に、HttpClientを閉じる
+
+        // アプリケーションが終了する際に、HttpClientをクローズする
+        // 画面の回転時もこの関数自体は呼ばれるため、isFinishingでユーザーがアプリを終了したかどうかを判定する
         if (isFinishing) {
             client.close()
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -4,6 +4,7 @@
 package jp.co.yumemi.android.code_check
 
 import androidx.appcompat.app.AppCompatActivity
+import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import java.util.Date
 
 /**
@@ -16,5 +17,13 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
         // 最後に検索した日時
         // 検索を実行した際に、この変数に現在時刻を代入する
         var lastSearchDate: Date? = null
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Activityが破棄される際に、HttpClientを閉じる
+        if (isFinishing) {
+            client.close()
+        }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoAdapter.kt
@@ -13,43 +13,7 @@ import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
 class RepositoryInfoAdapter(
     private val itemClickListener: (RepositoryInfoItem) -> Unit,
 ) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
-    // region inner class, objectの定義
     class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
-
-    /**
-     * RecyclerViewのアイテムの差分を計算し、 必要なアップデートのみを行うようにするためのCallback
-     */
-    object DiffCallback : DiffUtil.ItemCallback<RepositoryInfoItem>() {
-        /**
-         * 名前を比較し、二つのアイテムが同一のアイテムを表しているかどうかを判断する
-         *
-         * @param oldItem 古いリポジトリ情報
-         * @param newItem 新しいリポジトリ情報
-         */
-        override fun areItemsTheSame(
-            oldItem: RepositoryInfoItem,
-            newItem: RepositoryInfoItem,
-        ): Boolean {
-            return oldItem.name == newItem.name
-        }
-
-        /**
-         * 二つのアイテムのデータ内容が等しいかどうかを判断する
-         *
-         * @param oldItem 古いリポジトリ情報
-         * @param newItem 新しいリポジトリ情報
-         */
-        override fun areContentsTheSame(
-            oldItem: RepositoryInfoItem,
-            newItem: RepositoryInfoItem,
-        ): Boolean {
-            return oldItem == newItem
-        }
-    }
-
-    // endregion
-
-    // region override methods
 
     /**
      * ViewHolderが生成された際に呼び出される
@@ -88,3 +52,36 @@ class RepositoryInfoAdapter(
     }
     // endregion
 }
+
+/**
+ * RecyclerViewのアイテムの差分を計算し、 必要なアップデートのみを行うようにするためのCallback
+ */
+private object DiffCallback : DiffUtil.ItemCallback<RepositoryInfoItem>() {
+    /**
+     * 名前を比較し、二つのアイテムが同一のアイテムを表しているかどうかを判断する
+     *
+     * @param oldItem 古いリポジトリ情報
+     * @param newItem 新しいリポジトリ情報
+     */
+    override fun areItemsTheSame(
+        oldItem: RepositoryInfoItem,
+        newItem: RepositoryInfoItem,
+    ): Boolean {
+        return oldItem.name == newItem.name
+    }
+
+    /**
+     * 二つのアイテムのデータ内容が等しいかどうかを判断する
+     *
+     * @param oldItem 古いリポジトリ情報
+     * @param newItem 新しいリポジトリ情報
+     */
+    override fun areContentsTheSame(
+        oldItem: RepositoryInfoItem,
+        newItem: RepositoryInfoItem,
+    ): Boolean {
+        return oldItem == newItem
+    }
+}
+
+// endregion

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -81,7 +81,7 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
         binding?.apply {
             searchInputText.setOnEditorActionListener { editText, actionId, _ ->
                 if (actionId == EditorInfo.IME_ACTION_SEARCH) {
-                    viewModel.searchRepository(editText.text.toString())
+                    viewModel.executeSearchRepository(editText.text.toString())
                     true
                 } else {
                     false

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import okio.IOException
 import java.net.UnknownHostException
 import java.util.Date
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -117,9 +117,18 @@ data class Owner(
  * エラーの状態を表すsealed interface
  */
 sealed interface ErrorState {
+    /**
+     * 何もしていない状態
+     */
     object Idle : ErrorState
 
+    /**
+     * リポジトリ情報の取得に失敗した場合
+     */
     object CantFetchRepositoryInfo : ErrorState
 
+    /**
+     * ネットワークエラーが発生した場合
+     */
     object NetworkError : ErrorState
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -17,6 +17,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -36,32 +37,12 @@ class RepositorySearchViewModel : ViewModel() {
         private const val TAG = "RepositorySearchViewModel"
     }
 
-    private val client = HttpClient(Android) {
-        install(JsonFeature){
-            serializer = KotlinxSerializer(
-                json = kotlinx.serialization.json.Json {
-                    ignoreUnknownKeys = true
-                }
-            )
-        }
-    }
-
     private val _errorState: MutableStateFlow<ErrorState> = MutableStateFlow(ErrorState.Idle)
     val errorState = _errorState.asStateFlow()
 
     // StateFlowを使用して検索結果を保持
     private val _searchResults = MutableStateFlow<List<RepositoryInfoItem>>(emptyList())
     val searchResults = _searchResults.asStateFlow()
-
-    // region life cycle event
-    override fun onCleared() {
-        super.onCleared()
-        // HACK: 現状は一つのViewModelしか存在しないため、ここでclientをcloseしている
-        //       複数の画面で呼び出される場合はシングルトンにした方が良いため、必要に応じて修正する
-        client.close()
-    }
-    // endregion
-
 
     /**
      * inputTextを元にリポジトリを検索する

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/network/SingletonHttpClient.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/network/SingletonHttpClient.kt
@@ -1,0 +1,20 @@
+package jp.co.yumemi.android.code_check.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import kotlinx.serialization.json.Json
+
+// FIXME: Hiltを使ってDIする方がいい。今は時間がないため object で代用
+object HttpClientSingleton {
+    val client: HttpClient = HttpClient(Android) {
+        install(JsonFeature) {
+            serializer = KotlinxSerializer(
+                json = Json {
+                    ignoreUnknownKeys = true
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 概要
- AdapterのDiffCallbackをprivate objectに
- RepositorySearchViewModelの検索処理の責務分割はアーキテクチャの適応で #6 で行いたかったため割愛
- 同様の理由でMainActivityの最終検索日の更新も割愛

## 工夫した箇所
特になし

## 動作確認
通常の動作を壊していないことを確認。  
エビデンスは割愛