### PR TITLE
ViewModelの検索処理をRepositoryクラスに分離

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoAdapter.kt
@@ -5,14 +5,15 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
 import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
 
 /**
  * リポジトリ情報をRecyclerViewに表示するためのアダプター
  */
 class RepositoryInfoAdapter(
-    private val itemClickListener: (RepositoryInfoItem) -> Unit,
-) : ListAdapter<RepositoryInfoItem, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
+    private val itemClickListener: (GithubRepository) -> Unit,
+) : ListAdapter<GithubRepository, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
     class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
 
     /**
@@ -56,7 +57,7 @@ class RepositoryInfoAdapter(
 /**
  * RecyclerViewのアイテムの差分を計算し、 必要なアップデートのみを行うようにするためのCallback
  */
-private object DiffCallback : DiffUtil.ItemCallback<RepositoryInfoItem>() {
+private object DiffCallback : DiffUtil.ItemCallback<GithubRepository>() {
     /**
      * 名前を比較し、二つのアイテムが同一のアイテムを表しているかどうかを判断する
      *
@@ -64,8 +65,8 @@ private object DiffCallback : DiffUtil.ItemCallback<RepositoryInfoItem>() {
      * @param newItem 新しいリポジトリ情報
      */
     override fun areItemsTheSame(
-        oldItem: RepositoryInfoItem,
-        newItem: RepositoryInfoItem,
+        oldItem: GithubRepository,
+        newItem: GithubRepository,
     ): Boolean {
         return oldItem.name == newItem.name
     }
@@ -77,8 +78,8 @@ private object DiffCallback : DiffUtil.ItemCallback<RepositoryInfoItem>() {
      * @param newItem 新しいリポジトリ情報
      */
     override fun areContentsTheSame(
-        oldItem: RepositoryInfoItem,
-        newItem: RepositoryInfoItem,
+        oldItem: GithubRepository,
+        newItem: GithubRepository,
     ): Boolean {
         return oldItem == newItem
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoAdapter.kt
@@ -6,14 +6,15 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
+import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
 
 /**
  * リポジトリ情報をRecyclerViewに表示するためのアダプター
  */
 class RepositoryInfoAdapter(
-    private val itemClickListener: (GithubRepository) -> Unit,
-) : ListAdapter<GithubRepository, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
+    private val itemClickListener: (GithubRepositorySummary) -> Unit,
+) : ListAdapter<GithubRepositorySummary, RepositoryInfoAdapter.ViewHolder>(DiffCallback) {
     class ViewHolder(val binding: LayoutItemBinding) : RecyclerView.ViewHolder(binding.root)
 
     /**
@@ -57,7 +58,7 @@ class RepositoryInfoAdapter(
 /**
  * RecyclerViewのアイテムの差分を計算し、 必要なアップデートのみを行うようにするためのCallback
  */
-private object DiffCallback : DiffUtil.ItemCallback<GithubRepository>() {
+private object DiffCallback : DiffUtil.ItemCallback<GithubRepositorySummary>() {
     /**
      * 名前を比較し、二つのアイテムが同一のアイテムを表しているかどうかを判断する
      *
@@ -65,8 +66,8 @@ private object DiffCallback : DiffUtil.ItemCallback<GithubRepository>() {
      * @param newItem 新しいリポジトリ情報
      */
     override fun areItemsTheSame(
-        oldItem: GithubRepository,
-        newItem: GithubRepository,
+        oldItem: GithubRepositorySummary,
+        newItem: GithubRepositorySummary,
     ): Boolean {
         return oldItem.name == newItem.name
     }
@@ -78,8 +79,8 @@ private object DiffCallback : DiffUtil.ItemCallback<GithubRepository>() {
      * @param newItem 新しいリポジトリ情報
      */
     override fun areContentsTheSame(
-        oldItem: GithubRepository,
-        newItem: GithubRepository,
+        oldItem: GithubRepositorySummary,
+        newItem: GithubRepositorySummary,
     ): Boolean {
         return oldItem == newItem
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
@@ -49,7 +49,7 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
 
         binding = FragmentRepositoryInfoBinding.bind(view)
 
-        val repositoryInfo = args.repositoryInfoItem
+        val repositoryInfo = args.githubRepository
 
         binding?.apply {
             ownerIconView.load(repositoryInfo.owner.avatarUrl) {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryInfoFragment.kt
@@ -49,10 +49,10 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
 
         binding = FragmentRepositoryInfoBinding.bind(view)
 
-        val repositoryInfo = args.githubRepository
+        val repositoryInfo = args.githubRepositorySummary
 
         binding?.apply {
-            ownerIconView.load(repositoryInfo.owner.avatarUrl) {
+            ownerIconView.load(repositoryInfo.ownerIconUrl) {
                 placeholder(R.drawable.ic_android)
                 error(R.drawable.ic_android)
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -14,7 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
+import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositorySearchBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -152,13 +152,13 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
 
     /**
      * リポジトリ情報画面に遷移する
-     * @param githubRepository ユーザーによって選択されたリポジトリの情報
+     * @param githubRepositorySummary ユーザーによって選択されたリポジトリの情報
      */
-    private fun navigateRepositoryInfoFragment(githubRepository: GithubRepository) {
+    private fun navigateRepositoryInfoFragment(githubRepositorySummary: GithubRepositorySummary) {
         val action =
             RepositorySearchFragmentDirections
                 .actionRepositorySearchFragmentToRepositoryInfoFragment(
-                    githubRepository = githubRepository,
+                    githubRepositorySummary = githubRepositorySummary,
                 )
 
         findNavController().navigate(action)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositorySearchBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -151,13 +152,13 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
 
     /**
      * リポジトリ情報画面に遷移する
-     * @param repositoryInfoItem ユーザーによって選択されたリポジトリの情報
+     * @param githubRepository ユーザーによって選択されたリポジトリの情報
      */
-    private fun navigateRepositoryInfoFragment(repositoryInfoItem: RepositoryInfoItem) {
+    private fun navigateRepositoryInfoFragment(githubRepository: GithubRepository) {
         val action =
             RepositorySearchFragmentDirections
                 .actionRepositorySearchFragmentToRepositoryInfoFragment(
-                    repositoryInfoItem = repositoryInfoItem,
+                    githubRepository = githubRepository,
                 )
 
         findNavController().navigate(action)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -3,7 +3,6 @@
  */
 package jp.co.yumemi.android.code_check
 
-import android.os.Parcelable
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,13 +10,12 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
+import jp.co.yumemi.android.code_check.core.data.model.RepositorySearchResponse
 import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.parcelize.Parcelize
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import java.net.UnknownHostException
 import java.util.Date
@@ -34,7 +32,7 @@ class RepositorySearchViewModel : ViewModel() {
     val errorState = _errorState.asStateFlow()
 
     // StateFlowを使用して検索結果を保持
-    private val _searchResults = MutableStateFlow<List<RepositoryInfoItem>>(emptyList())
+    private val _searchResults = MutableStateFlow<List<GithubRepository>>(emptyList())
     val searchResults = _searchResults.asStateFlow()
 
     /**
@@ -91,43 +89,6 @@ class RepositorySearchViewModel : ViewModel() {
     }
 }
 
-
-@Parcelize
-@Serializable
-data class RepositorySearchResponse(
-    val items: List<RepositoryInfoItem>
-) : Parcelable
-
-
-/**
- * Githubのリポジトリ情報
- */
-@Parcelize
-@Serializable
-data class RepositoryInfoItem(
-    @SerialName("full_name")
-    val name: String,
-    @SerialName("owner")
-    val owner: Owner,
-    @SerialName("language")
-    val language: String?,
-    @SerialName("stargazers_count")
-    val stargazersCount: Long,
-    @SerialName("watchers_count")
-    val watchersCount: Long,
-    @SerialName("forks_count")
-    val forksCount: Long,
-    @SerialName("open_issues_count")
-    val openIssuesCount: Long,
-) : Parcelable
-
-
-@Parcelize
-@Serializable
-data class Owner(
-    @SerialName("avatar_url")
-    val avatarUrl: String,
-) : Parcelable
 /**
  * エラーの状態を表すsealed interface
  */

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -10,8 +10,10 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepositoryImpl
 import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
 import jp.co.yumemi.android.code_check.core.data.model.RepositorySearchResponse
+import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -28,11 +30,14 @@ class RepositorySearchViewModel : ViewModel() {
         private const val TAG = "RepositorySearchViewModel"
     }
 
+    // FIXME: 本当はHiltでDIしたい
+    private val githubRepositoryRepository = GithubRepositoryRepositoryImpl()
+
     private val _errorState: MutableStateFlow<ErrorState> = MutableStateFlow(ErrorState.Idle)
     val errorState = _errorState.asStateFlow()
 
     // StateFlowを使用して検索結果を保持
-    private val _searchResults = MutableStateFlow<List<GithubRepository>>(emptyList())
+    private val _searchResults = MutableStateFlow<List<GithubRepositorySummary>>(emptyList())
     val searchResults = _searchResults.asStateFlow()
 
     /**
@@ -44,8 +49,8 @@ class RepositorySearchViewModel : ViewModel() {
     fun executeSearchRepository(inputText: String) {
         viewModelScope.launch {
             try {
-                val response: RepositorySearchResponse = searchRepository(inputText)
-                _searchResults.value = response.items
+                val searchResults = githubRepositoryRepository.searchRepository(inputText)
+                _searchResults.value = searchResults
             } catch (e: Exception) {
                 handleError(e)
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepository.kt
@@ -1,7 +1,7 @@
 package jp.co.yumemi.android.code_check.core.data
 
-import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
+import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 
 interface GithubRepositoryRepository {
-    suspend fun getGithubRepositoryList(): List<GithubRepository>
+    suspend fun searchRepository(query: String): List<GithubRepositorySummary>
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepository.kt
@@ -1,0 +1,7 @@
+package jp.co.yumemi.android.code_check.core.data
+
+import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
+
+interface GithubRepositoryRepository {
+    suspend fun getGithubRepositoryList(): List<GithubRepository>
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package jp.co.yumemi.android.code_check.core.data
+
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import jp.co.yumemi.android.code_check.core.data.model.RepositorySearchResponse
+import jp.co.yumemi.android.code_check.core.data.model.toExternalModel
+import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
+import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
+
+/**
+ * Githubのレポジトリにまつわるデータを取得する
+ */
+class GithubRepositoryRepositoryImpl : GithubRepositoryRepository {
+    override suspend fun searchRepository(query: String): List<GithubRepositorySummary> {
+        val response: RepositorySearchResponse =
+            client.get("https://api.github.com/search/repositories") {
+            header("Accept", "application/vnd.github.v3+json")
+            parameter("q", query)
+        }
+
+        return response.items.map { it.toExternalModel() }
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/GithubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/GithubRepository.kt
@@ -7,9 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Githubのリポジトリ情報
- * TODO: Parcelableを除去する
  */
-@Parcelize
 @Serializable
 data class GithubRepository(
     @SerialName("full_name")
@@ -26,12 +24,11 @@ data class GithubRepository(
     val forksCount: Long,
     @SerialName("open_issues_count")
     val openIssuesCount: Long,
-) : Parcelable
+)
 
 
-@Parcelize
 @Serializable
 data class Owner(
     @SerialName("avatar_url")
     val avatarUrl: String,
-) : Parcelable
+)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/GithubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/GithubRepository.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * Githubのリポジトリ情報
+ * TODO: Parcelableを除去する
  */
 @Parcelize
 @Serializable

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/GithubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/GithubRepository.kt
@@ -1,0 +1,36 @@
+package jp.co.yumemi.android.code_check.core.data.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Githubのリポジトリ情報
+ */
+@Parcelize
+@Serializable
+data class GithubRepository(
+    @SerialName("full_name")
+    val name: String,
+    @SerialName("owner")
+    val owner: Owner,
+    @SerialName("language")
+    val language: String?,
+    @SerialName("stargazers_count")
+    val stargazersCount: Long,
+    @SerialName("watchers_count")
+    val watchersCount: Long,
+    @SerialName("forks_count")
+    val forksCount: Long,
+    @SerialName("open_issues_count")
+    val openIssuesCount: Long,
+) : Parcelable
+
+
+@Parcelize
+@Serializable
+data class Owner(
+    @SerialName("avatar_url")
+    val avatarUrl: String,
+) : Parcelable

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/GithubRepositoryMapper.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/GithubRepositoryMapper.kt
@@ -1,0 +1,16 @@
+package jp.co.yumemi.android.code_check.core.data.model
+
+import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
+
+
+fun GithubRepository.toExternalModel(): GithubRepositorySummary {
+    return GithubRepositorySummary(
+        name = name,
+        ownerIconUrl = owner.avatarUrl,
+        language = language,
+        stargazersCount = stargazersCount,
+        watchersCount = watchersCount,
+        forksCount = forksCount,
+        openIssuesCount = openIssuesCount,
+    )
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/RepositorySearchResponse.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/RepositorySearchResponse.kt
@@ -1,0 +1,16 @@
+package jp.co.yumemi.android.code_check.core.data.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
+
+/**
+ * リポジトリ検索APIのレスポンス
+ */
+@Parcelize
+@Serializable
+data class RepositorySearchResponse(
+    val items: List<GithubRepository>
+) : Parcelable
+
+

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/RepositorySearchResponse.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/model/RepositorySearchResponse.kt
@@ -1,16 +1,12 @@
 package jp.co.yumemi.android.code_check.core.data.model
 
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 /**
  * リポジトリ検索APIのレスポンス
  */
-@Parcelize
 @Serializable
 data class RepositorySearchResponse(
     val items: List<GithubRepository>
-) : Parcelable
-
+)
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/model/GithubRepositorySummary.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/model/GithubRepositorySummary.kt
@@ -1,0 +1,19 @@
+package jp.co.yumemi.android.code_check.core.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+
+/**
+ * Githubのリポジトリ情報
+ */
+@Parcelize
+data class GithubRepositorySummary(
+    val name: String,
+    val ownerIconUrl: String,
+    val language: String?,
+    val stargazersCount: Long,
+    val watchersCount: Long,
+    val forksCount: Long,
+    val openIssuesCount: Long,
+) : Parcelable

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -21,8 +21,8 @@
         android:label="@string/repository_info"
         tools:layout="@layout/fragment_repository_info">
         <argument
-            android:name="githubRepository"
-            app:argType="jp.co.yumemi.android.code_check.core.data.model.GithubRepository" />
+            android:name="githubRepositorySummary"
+            app:argType="jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary" />
     </fragment>
 
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -21,8 +21,8 @@
         android:label="@string/repository_info"
         tools:layout="@layout/fragment_repository_info">
         <argument
-            android:name="repositoryInfoItem"
-            app:argType="jp.co.yumemi.android.code_check.RepositoryInfoItem" />
+            android:name="githubRepository"
+            app:argType="jp.co.yumemi.android.code_check.core.data.model.GithubRepository" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
## 概要
単一責務の原則に近づけるため、部分的にアーキテクチャの適用 #6 の対応をした  
Now in Android のようなパッケージ構造にした

- Repositoryクラスの作成
- data レイヤの modelを作成
- core model(application全体で使うmodel)を作成
- ViewModelの検索処理を除去し、Repositoryクラスで行うように修正

本来はApiクラスなども作成した方が良いと思うが、修正範囲が大きくなり過ぎてしまうためやっていない

## 工夫した箇所
- マルチモジュール化が必要になった時、対応が簡単なようなディレクトリ構造に
- Data レイヤのModelと core.modelを用意
- Data -> View の通信で View側がDataレイヤのコンテキストを理解しなくても良いように修正。
  - これによって Data レイヤのモデルが変更された際の、View側への影響が少なくなるはず

## 反省点
- 差分がわかりづらく、レビューが大変になってしまっているかも。
- この対応の前にもっと適切に実装できてればもう少しわかりやすかったはず

## 動作確認
通常の動作が壊れていないことを確認  
エビデンスは割愛