### PR TITLE
インターフェースの分離原則を適用するため Hiltを導入

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'kotlin-parcelize'
     id 'androidx.navigation.safeargs.kotlin'
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.21'
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
@@ -40,7 +41,6 @@ android {
 }
 
 dependencies {
-
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
@@ -62,6 +62,10 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3'
 
     implementation 'io.coil-kt:coil:1.3.2'
+
+    implementation "com.google.dagger:hilt-android:2.44"
+    kapt "com.google.dagger:hilt-compiler:2.44"
+
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidEngineerCodeCheck"
-        android:fullBackupContent="@xml/backup_descriptor">
+        android:fullBackupContent="@xml/backup_descriptor"
+        android:name=".CodeCheckApplication">
         <activity
             android:name="jp.co.yumemi.android.code_check.MainActivity"
             android:exported="true">

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/CodeCheckApplication.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/CodeCheckApplication.kt
@@ -1,0 +1,7 @@
+package jp.co.yumemi.android.code_check
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class CodeCheckApplication: Application()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -5,6 +5,7 @@ package jp.co.yumemi.android.code_check
 
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
 import java.util.Date
 
@@ -12,6 +13,7 @@ import java.util.Date
  * 本アプリのMainActivity
  * このアクティビティが本アプリのエントリーポイントとなる
  */
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity(R.layout.activity_main) {
     // FIXME: Jetpack Datastoreなどを使用した方が良い気がする。
     companion object {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositorySearchBinding
 import kotlinx.coroutines.flow.launchIn
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.onEach
  * リポジトリ検索画面
  * 画面上部のテキストフィールドに入力された文字列を元に、Githubのレポジトリを検索する
  */
+@AndroidEntryPoint
 class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
     private var binding: FragmentRepositorySearchBinding? = null
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -6,10 +6,12 @@ package jp.co.yumemi.android.code_check
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepository
 import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepositoryImpl
 import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
 import jp.co.yumemi.android.code_check.core.data.model.RepositorySearchResponse
@@ -21,17 +23,18 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
 import java.net.UnknownHostException
 import java.util.Date
+import javax.inject.Inject
 
 /**
  * リポジトリ検索画面のViewModel
  */
-class RepositorySearchViewModel : ViewModel() {
+@HiltViewModel
+class RepositorySearchViewModel @Inject constructor(
+    private val githubRepositoryRepository: GithubRepositoryRepository
+): ViewModel() {
     companion object {
         private const val TAG = "RepositorySearchViewModel"
     }
-
-    // FIXME: 本当はHiltでDIしたい
-    private val githubRepositoryRepository = GithubRepositoryRepositoryImpl()
 
     private val _errorState: MutableStateFlow<ErrorState> = MutableStateFlow(ErrorState.Idle)
     val errorState = _errorState.asStateFlow()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositorySearchViewModel.kt
@@ -70,18 +70,6 @@ class RepositorySearchViewModel @Inject constructor(
     }
 
     /**
-     * FIXME: 本来はRepositoryクラスを作成し、そこでAPIのリクエストを行うべき
-     *        アーキテクチャ適用のissueで対応する
-     * GithubのAPIにRequestしてリポジトリ情報を取得する
-     */
-    private suspend fun searchRepository(inputText: String): RepositorySearchResponse {
-        return client.get("https://api.github.com/search/repositories") {
-            header("Accept", "application/vnd.github.v3+json")
-            parameter("q", inputText)
-        }
-    }
-
-    /**
      * エラーをハンドリングする
      */
     private fun handleError(e: Exception) {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepositoryImpl.kt
@@ -7,11 +7,12 @@ import jp.co.yumemi.android.code_check.core.data.model.RepositorySearchResponse
 import jp.co.yumemi.android.code_check.core.data.model.toExternalModel
 import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.network.HttpClientSingleton.client
+import javax.inject.Inject
 
 /**
  * Githubのレポジトリにまつわるデータを取得する
  */
-class GithubRepositoryRepositoryImpl : GithubRepositoryRepository {
+class GithubRepositoryRepositoryImpl @Inject constructor(): GithubRepositoryRepository {
     override suspend fun searchRepository(query: String): List<GithubRepositorySummary> {
         val response: RepositorySearchResponse =
             client.get("https://api.github.com/search/repositories") {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/di/RepositoryModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/di/RepositoryModule.kt
@@ -1,0 +1,17 @@
+package jp.co.yumemi.android.code_check.core.data.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepository
+import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepositoryImpl
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface RepositoryModule {
+    @Binds
+    fun bindGithubRepositoryRepository(
+        githubRepositoryRepositoryImpl: GithubRepositoryRepositoryImpl
+    ): GithubRepositoryRepository
+}

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.google.dagger.hilt.android' version '2.44' apply false
+}
+
 tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
## 概要
ViewModelにて完全にインターフェースの分離原則を適用できていなかった。
他にもやり方はあったが、Hiltが慣れていたのでHiltでDIすることで、ViewModelはRepositoryの実装を知らなくても良いようにした。

また、MainActivityで最後に検索した日付を保持しているのをDatastoreに置き換えるためにも、Hiltは入れておくと便利なのでここで組み込むことにした。

- Hiltの依存を追加
- ViewModelにRepositoryをDIするための設定を追加

## 工夫した箇所
特になし


## 動作確認
通常の動作が破壊されていないことを確認
