### PR TITLE
各ファイルのPackageを移動

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -6,6 +6,7 @@ package jp.co.yumemi.android.code_check
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import io.ktor.client.HttpClient
+import jp.co.yumemi.android.code_check.R
 import java.util.Date
 import javax.inject.Inject
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/network/NetworkModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/network/NetworkModule.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.android.code_check.network
+package jp.co.yumemi.android.code_check.core.network
 
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositoryInfoAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositoryInfoAdapter.kt
@@ -1,11 +1,10 @@
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.code_check.feature.repository.search
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import jp.co.yumemi.android.code_check.core.data.model.GithubRepository
 import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositoryInfoFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.code_check.feature.repository.search
 
 import android.os.Bundle
 import android.util.Log
@@ -9,6 +9,7 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
+import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositoryInfoBinding
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositorySearchFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.code_check.feature.repository.search
 
 import android.content.Context
 import android.os.Bundle
@@ -15,6 +15,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositorySearchBinding
 import kotlinx.coroutines.flow.launchIn
@@ -158,10 +159,9 @@ class RepositorySearchFragment : Fragment(R.layout.fragment_repository_search) {
      */
     private fun navigateRepositoryInfoFragment(githubRepositorySummary: GithubRepositorySummary) {
         val action =
-            RepositorySearchFragmentDirections
-                .actionRepositorySearchFragmentToRepositoryInfoFragment(
-                    githubRepositorySummary = githubRepositorySummary,
-                )
+            RepositorySearchFragmentDirections.actionRepositorySearchFragmentToRepositoryInfoFragment(
+                githubRepositorySummary = githubRepositorySummary,
+            )
 
         findNavController().navigate(action)
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositorySearchViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.code_check.feature.repository.search
 
 import android.util.Log
 import androidx.lifecycle.ViewModel

--- a/app/src/main/res/layout/fragment_repository_search.xml
+++ b/app/src/main/res/layout/fragment_repository_search.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".RepositorySearchFragment">
+    tools:context=".feature.repository.search.RepositorySearchFragment">
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/searchBar"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/repositorySearchFragment"
-        android:name="jp.co.yumemi.android.code_check.RepositorySearchFragment"
+        android:name="jp.co.yumemi.android.code_check.feature.repository.search.RepositorySearchFragment"
         android:label="@string/repositories_search"
         tools:layout="@layout/fragment_repository_search">
         <action
@@ -17,7 +17,7 @@
 
     <fragment
         android:id="@+id/repositoryInfoFragment"
-        android:name="jp.co.yumemi.android.code_check.RepositoryInfoFragment"
+        android:name="jp.co.yumemi.android.code_check.feature.repository.search.RepositoryInfoFragment"
         android:label="@string/repository_info"
         tools:layout="@layout/fragment_repository_info">
         <argument


### PR DESCRIPTION
## 概要
- network -> coreに移動
- View系 -> feature/repository/search というパッケージを作りそこに移動

## 工夫した箇所
- パッケージ構造をNow in Android のマルチモジュールの構成に似たものに
- 時間があったらマルチモジュール化も視野に入れているため、後々対応しやすいように

## 動作確認
- 既存の機能が壊れていないことを確認
- エビデンスは割愛
