### PR TITLE
API クラスを作成

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/api/github/GithubSearchApi.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/api/github/GithubSearchApi.kt
@@ -10,6 +10,12 @@ import javax.inject.Inject
 class GithubSearchApi @Inject constructor(
     private val httpClient: HttpClient
 ){
+    /**
+     * Githubのレポジトリを検索する
+     * エンドポイント: search/repositories
+     *
+     * @param query 検索文字列, request parameter: q
+     */
     suspend fun searchRepository(query: String): RepositorySearchResponse {
         val response: RepositorySearchResponse =
             httpClient.get("https://api.github.com/search/repositories") {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/api/github/GithubSearchApi.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/api/github/GithubSearchApi.kt
@@ -1,0 +1,22 @@
+package jp.co.yumemi.android.code_check.core.api.github
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import jp.co.yumemi.android.code_check.core.data.model.RepositorySearchResponse
+import javax.inject.Inject
+
+class GithubSearchApi @Inject constructor(
+    private val httpClient: HttpClient
+){
+    suspend fun searchRepository(query: String): RepositorySearchResponse {
+        val response: RepositorySearchResponse =
+            httpClient.get("https://api.github.com/search/repositories") {
+                header("Accept", "application/vnd.github.v3+json")
+                parameter("q", query)
+            }
+
+        return response
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepositoryImpl.kt
@@ -16,6 +16,12 @@ import javax.inject.Inject
 class GithubRepositoryRepositoryImpl @Inject constructor(
     private val githubSearchApi: GithubSearchApi,
 ): GithubRepositoryRepository {
+    /**
+     * Githubのレポジトリを検索する
+     *
+     * @param query 検索文字列
+     * @return リポジトリ概要のリスト
+     */
     override suspend fun searchRepository(query: String): List<GithubRepositorySummary> {
         val response: RepositorySearchResponse = githubSearchApi.searchRepository(query)
         return response.items.map { it.toExternalModel() }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/GithubRepositoryRepositoryImpl.kt
@@ -7,21 +7,17 @@ import io.ktor.client.request.parameter
 import jp.co.yumemi.android.code_check.core.data.model.RepositorySearchResponse
 import jp.co.yumemi.android.code_check.core.data.model.toExternalModel
 import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
+import jp.co.yumemi.android.code_check.core.api.github.GithubSearchApi
 import javax.inject.Inject
 
 /**
  * Githubのレポジトリにまつわるデータを取得する
  */
 class GithubRepositoryRepositoryImpl @Inject constructor(
-    private val httpClient: HttpClient
+    private val githubSearchApi: GithubSearchApi,
 ): GithubRepositoryRepository {
     override suspend fun searchRepository(query: String): List<GithubRepositorySummary> {
-        val response: RepositorySearchResponse =
-            httpClient.get("https://api.github.com/search/repositories") {
-            header("Accept", "application/vnd.github.v3+json")
-            parameter("q", query)
-        }
-
+        val response: RepositorySearchResponse = githubSearchApi.searchRepository(query)
         return response.items.map { it.toExternalModel() }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/model/GithubRepositorySummary.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/model/GithubRepositorySummary.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 
 
 /**
- * Githubのリポジトリ情報
+ * Githubのリポジトリ概要
  */
 @Parcelize
 data class GithubRepositorySummary(


### PR DESCRIPTION
## 概要
Repositoryの責務の中にAPIへのリクエストも含まれてしまっていたため修正(本来は #5 で行うべきだったが失念していた)
- APIクラスを作成
- それをRepositoryクラスで使用するように修正

## 工夫した箇所
- APIクラスを networkディレクトリにおいてもよかったが、apiディレクトリの中に置くことにした
- 仮に今後Githubの色々なAPIをサポートすると仮定すると、APIクラスが増えてnetworkが肥大すると良くないと考えたため
  - マルチモジュール化する場合はapiも個別のモジュールにする想定

## 動作確認
- 通常の動作が壊れていないことを確認
- エビデンスは割愛