### PR TITLE
最新の検索日をDatastoreで管理するように修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,10 @@ dependencies {
     implementation 'io.coil-kt:coil:1.3.2'
 
     implementation "com.google.dagger:hilt-android:2.44"
+
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
+    implementation "androidx.datastore:datastore-preferences-core:1.0.0"
+
     kapt "com.google.dagger:hilt-compiler:2.44"
 
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -20,13 +20,6 @@ class MainActivity : AppCompatActivity(R.layout.activity_main) {
     @Inject
     lateinit var client: HttpClient
 
-    // FIXME: Jetpack Datastoreなどを使用した方が良い気がする。
-    companion object {
-        // 最後に検索した日時
-        // 検索を実行した際に、この変数に現在時刻を代入する
-        var lastSearchDate: Date? = null
-    }
-
     /**
      * 下記のタイミングで呼び出される
      * 1. アプリケーションがユーザーによって終了される場合。

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/OfflineUserDataRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/OfflineUserDataRepository.kt
@@ -1,0 +1,18 @@
+package jp.co.yumemi.android.code_check.core.data
+
+import android.service.autofill.UserData
+import jp.co.yumemi.android.code_check.core.datastore.CodeCheckAppPreferencesDatasource
+import kotlinx.coroutines.flow.Flow
+import java.util.Date
+import javax.inject.Inject
+
+class OfflineUserDataRepository @Inject constructor(
+    private val codeCheckAppPreferencesDatasource: CodeCheckAppPreferencesDatasource
+): UserDataRepository {
+    override val latestSearchDate: Flow<Date?>
+        get() = codeCheckAppPreferencesDatasource.lastSearchDate
+
+    override suspend fun saveLastSearchDate(date: Date) {
+        codeCheckAppPreferencesDatasource.saveLastSearchDate(date)
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/UserDataRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/UserDataRepository.kt
@@ -1,0 +1,10 @@
+package jp.co.yumemi.android.code_check.core.data
+
+import kotlinx.coroutines.flow.Flow
+import java.util.Date
+
+interface UserDataRepository {
+    val latestSearchDate: Flow<Date?>
+
+    suspend fun saveLastSearchDate(date: Date)
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/di/RepositoryModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/di/RepositoryModule.kt
@@ -6,6 +6,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepository
 import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepositoryImpl
+import jp.co.yumemi.android.code_check.core.data.OfflineUserDataRepository
+import jp.co.yumemi.android.code_check.core.data.UserDataRepository
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -14,4 +16,9 @@ interface RepositoryModule {
     fun bindGithubRepositoryRepository(
         githubRepositoryRepositoryImpl: GithubRepositoryRepositoryImpl
     ): GithubRepositoryRepository
+
+    @Binds
+    fun bindUserDataRepository(
+        userDataRepository: OfflineUserDataRepository
+    ): UserDataRepository
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/datastore/CodeCheckAppPreferencesDatasource.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/datastore/CodeCheckAppPreferencesDatasource.kt
@@ -1,0 +1,32 @@
+package jp.co.yumemi.android.code_check.core.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import kotlinx.coroutines.flow.map
+import java.util.Date
+import javax.inject.Inject
+
+class CodeCheckAppPreferencesDatasource @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+){
+    companion object {
+        private val LATEST_SEARCH_DATE = longPreferencesKey("latest_search_date")
+    }
+
+    suspend fun saveLastSearchDate(date: Date) {
+        dataStore.edit { settings ->
+            settings[LATEST_SEARCH_DATE] = date.time
+        }
+    }
+
+    val lastSearchDate = dataStore.data.map { settings ->
+        val latestSearchDateTime = settings[LATEST_SEARCH_DATE]
+        if (latestSearchDateTime != null) {
+            Date(latestSearchDateTime)
+        } else {
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/datastore/di/DataStoreModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/datastore/di/DataStoreModule.kt
@@ -9,14 +9,17 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
-@InstallIn
+@InstallIn(SingletonComponent::class)
 object DataStoreModule {
     @Provides
     @Singleton
-    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+    fun provideDataStore(
+        @ApplicationContext context: Context
+    ): DataStore<Preferences> {
         return PreferenceDataStoreFactory.create(
             produceFile = { context.preferencesDataStoreFile("settings") }
         )

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/datastore/di/DataStoreModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/datastore/di/DataStoreModule.kt
@@ -1,0 +1,24 @@
+package jp.co.yumemi.android.code_check.core.datastore.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Singleton
+
+@Module
+@InstallIn
+object DataStoreModule {
+    @Provides
+    @Singleton
+    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile("settings") }
+        )
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositoryInfoFragment.kt
@@ -12,9 +12,7 @@ import androidx.navigation.fragment.navArgs
 import coil.load
 import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.R
-import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.core.data.UserDataRepository
-import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositoryInfoBinding
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositoryInfoFragment.kt
@@ -7,15 +7,23 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
 import coil.load
+import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.code_check.core.data.UserDataRepository
+import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositoryInfoBinding
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 /**
  * リポジトリ情報画面
  */
+@AndroidEntryPoint
 class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
     companion object {
         private const val TAG = "RepositoryInfoFragment"
@@ -24,6 +32,8 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
     private val args: RepositoryInfoFragmentArgs by navArgs()
 
     private var binding: FragmentRepositoryInfoBinding? = null
+
+    @Inject lateinit var userDataRepository: UserDataRepository
 
     override fun onDestroyView() {
         super.onDestroyView()
@@ -46,27 +56,34 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        Log.d(TAG, "検索した日時: $lastSearchDate")
+        lifecycleScope.launch {
+            val lastSearchDate = userDataRepository.latestSearchDate.first()
+            Log.d(TAG, "検索した日時: $lastSearchDate")
+        }
 
         binding = FragmentRepositoryInfoBinding.bind(view)
 
-        val repositoryInfo = args.githubRepositorySummary
+        applyRepositorySummary()
+    }
+
+    private fun applyRepositorySummary () {
+        val repositorySummary = args.githubRepositorySummary
 
         binding?.apply {
-            ownerIconView.load(repositoryInfo.ownerIconUrl) {
+            ownerIconView.load(repositorySummary.ownerIconUrl) {
                 placeholder(R.drawable.ic_android)
                 error(R.drawable.ic_android)
             }
-            nameView.text = repositoryInfo.name
-            languageView.text = if (repositoryInfo.language !== null){
-                getString(R.string.written_language, repositoryInfo.language)
+            nameView.text = repositorySummary.name
+            languageView.text = if (repositorySummary.language !== null){
+                getString(R.string.written_language, repositorySummary.language)
             } else {
                 getString(R.string.language_not_specified)
             }
-            starsView.text = getString(R.string.star_count_text, repositoryInfo.stargazersCount)
-            watchersView.text = getString(R.string.watcher_count_text, repositoryInfo.watchersCount)
-            forksView.text = getString(R.string.fork_count_text, repositoryInfo.forksCount)
-            openIssuesView.text = getString(R.string.open_issue_count_text, repositoryInfo.openIssuesCount)
+            starsView.text = getString(R.string.star_count_text, repositorySummary.stargazersCount)
+            watchersView.text = getString(R.string.watcher_count_text, repositorySummary.watchersCount)
+            forksView.text = getString(R.string.fork_count_text, repositorySummary.forksCount)
+            openIssuesView.text = getString(R.string.open_issue_count_text, repositorySummary.openIssuesCount)
         }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositorySearchViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.ktor.client.features.ClientRequestException
-import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepository
 import jp.co.yumemi.android.code_check.core.data.UserDataRepository
 import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/search/RepositorySearchViewModel.kt
@@ -7,8 +7,10 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.ktor.client.features.ClientRequestException
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepository
+import jp.co.yumemi.android.code_check.core.data.UserDataRepository
 import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,7 +25,8 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class RepositorySearchViewModel @Inject constructor(
-    private val githubRepositoryRepository: GithubRepositoryRepository
+    private val githubRepositoryRepository: GithubRepositoryRepository,
+    private val userDataRepository: UserDataRepository
 ): ViewModel() {
     companion object {
         private const val TAG = "RepositorySearchViewModel"
@@ -51,7 +54,8 @@ class RepositorySearchViewModel @Inject constructor(
                 handleError(e)
             }
 
-            lastSearchDate = Date()
+            // 検索した日時を保存する
+            userDataRepository.saveLastSearchDate(Date())
         }
     }
 
@@ -73,6 +77,12 @@ class RepositorySearchViewModel @Inject constructor(
             }
             is UnknownHostException -> {
                 _errorState.value = ErrorState.NetworkError
+            }
+            is ClientRequestException -> {
+                _errorState.value = ErrorState.NetworkError
+            }
+            else -> {
+                _errorState.value = ErrorState.CantFetchRepositoryInfo
             }
         }
     }


### PR DESCRIPTION
## 概要
MainActivityで latestSearchDateを保持するのはややMainActivityの責務から外れている気がした
そのため、Datastoreを使いlatestSearchDateを保存するようにした

## 工夫した箇所
- DIで Datastoreを使用するようにしたこと

## 動作確認
### 正常系
通常の動作が壊されていないことを確認

### ログ
Datastoreにしてもログが出力されることを確認。
オペレーションは 検索文字列入力 -> 検索 -> レポジトリ情報へ -> 戻る -> 検索文字列変更 -> 検索 ... 繰り返し

<img width="1355" alt="スクリーンショット 2024-01-17 20 50 19" src="https://github.com/Ren-Toyokawa/android-engineer-codecheck/assets/23397943/ba63b8b5-2e61-4a42-b3f7-46d07ccf1b11">

