### PR TITLE
UIテストの追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'io.coil-kt:coil:1.3.2'
 
     implementation "com.google.dagger:hilt-android:2.44"
+    implementation 'com.google.dagger:hilt-android-testing:2.44'
 
     implementation "androidx.datastore:datastore-preferences:1.0.0"
     implementation "androidx.datastore:datastore-preferences-core:1.0.0"
@@ -76,6 +77,13 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.10.3'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
+
+
+
+
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'jp.co.yumemi.android.code_check.core.testing.CodeCheckAppTestRunner'
     }
 
     buildTypes {
@@ -65,11 +65,15 @@ dependencies {
 
     implementation "com.google.dagger:hilt-android:2.44"
     implementation 'com.google.dagger:hilt-android-testing:2.44'
+    androidTestImplementation 'com.google.dagger:hilt-android-testing:2.44'
 
     implementation "androidx.datastore:datastore-preferences:1.0.0"
     implementation "androidx.datastore:datastore-preferences-core:1.0.0"
 
+    implementation 'androidx.test:runner:1.1.0'
+
     kapt "com.google.dagger:hilt-compiler:2.44"
+    kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.44'
 
 
     testImplementation 'junit:junit:4.13.2'
@@ -80,10 +84,5 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
-
-
-
-
-
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
 }

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/di/TestRepositoryModule.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/di/TestRepositoryModule.kt
@@ -1,0 +1,30 @@
+package jp.co.yumemi.android.code_check.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepository
+import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepositoryImpl
+import jp.co.yumemi.android.code_check.core.data.OfflineUserDataRepository
+import jp.co.yumemi.android.code_check.core.data.UserDataRepository
+import jp.co.yumemi.android.code_check.core.data.di.RepositoryModule
+import jp.co.yumemi.android.code_check.core.data.fake.FakeGithubRepositoryRepository
+import jp.co.yumemi.android.code_check.core.data.fake.FakeUserDataRepository
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [RepositoryModule::class],
+)
+interface TestRepositoryModule {
+    @Binds
+    fun bindGithubRepositoryRepository(
+        githubRepositoryRepositoryImpl: FakeGithubRepositoryRepository
+    ): GithubRepositoryRepository
+
+    @Binds
+    fun bindUserDataRepository(
+        userDataRepository: FakeUserDataRepository
+    ): UserDataRepository
+}

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/feature/RepositorySearchFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/feature/RepositorySearchFragmentTest.kt
@@ -11,18 +11,22 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.ActivityTestRule
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
 import jp.co.yumemi.android.code_check.MainActivity
 import jp.co.yumemi.android.code_check.R
-import kotlinx.coroutines.delay
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 class RepositorySearchFragmentTest {
 
-    @get:Rule
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
     var activityRule = ActivityScenarioRule(MainActivity::class.java)
 
     @Test
@@ -38,9 +42,6 @@ class RepositorySearchFragmentTest {
 
         // RecyclerViewのアイテムが表示されることを確認
         onView(withId(R.id.recyclerView)).check(matches(isDisplayed()))
-
-        // これはやるべきではない
-        Thread.sleep(5000)
 
         // RecyclerViewの最初のアイテムをタップ
         onView(withId(R.id.recyclerView))

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/feature/RepositorySearchFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/feature/RepositorySearchFragmentTest.kt
@@ -1,0 +1,62 @@
+package jp.co.yumemi.android.code_check.feature
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.pressImeActionButton
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import jp.co.yumemi.android.code_check.MainActivity
+import jp.co.yumemi.android.code_check.R
+import kotlinx.coroutines.delay
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RepositorySearchFragmentTest {
+
+    @get:Rule
+    var activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun search_scenario() {
+        // 検索バーにテキストを入力
+        onView(withId(R.id.searchInputText))
+            .perform(
+                typeText("Android")
+            )
+
+        // 検索ボタンをタップ
+        onView(withId(R.id.searchInputText)).perform(pressImeActionButton())
+
+        // RecyclerViewのアイテムが表示されることを確認
+        onView(withId(R.id.recyclerView)).check(matches(isDisplayed()))
+
+        // これはやるべきではない
+        Thread.sleep(5000)
+
+        // RecyclerViewの最初のアイテムをタップ
+        onView(withId(R.id.recyclerView))
+            .perform(
+                RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(
+                    0, click()
+                )
+            )
+
+        // RepositoryInfoFragmentのViewが表示されることを確認
+        onView(withId(R.id.ownerIconView)).check(matches(isDisplayed()))
+        onView(withId(R.id.nameView)).check(matches(isDisplayed()))
+        onView(withId(R.id.languageView)).check(matches(isDisplayed()))
+        onView(withId(R.id.starsView)).check(matches(isDisplayed()))
+        onView(withId(R.id.watchersView)).check(matches(isDisplayed()))
+        onView(withId(R.id.forksView)).check(matches(isDisplayed()))
+        onView(withId(R.id.openIssuesView)).check(matches(isDisplayed()))
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/fake/FakeGithubRepositoryRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/fake/FakeGithubRepositoryRepository.kt
@@ -1,0 +1,86 @@
+package jp.co.yumemi.android.code_check.core.data.fake
+
+import jp.co.yumemi.android.code_check.core.data.GithubRepositoryRepository
+import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
+import javax.inject.Inject
+
+class FakeGithubRepositoryRepository @Inject constructor(): GithubRepositoryRepository {
+    override suspend fun searchRepository(query: String): List<GithubRepositorySummary> {
+        return dummyData
+    }
+}
+
+private val dummyData = listOf(
+    GithubRepositorySummary(
+        name = "dummy1",
+        ownerIconUrl = "https://dummy1.com",
+        language = "Kotlin",
+        stargazersCount = 100,
+        watchersCount = 100,
+        forksCount = 100,
+        openIssuesCount = 100,
+    ),
+    GithubRepositorySummary(
+        name = "dummy2",
+        ownerIconUrl = "https://dummy2.com",
+        language = "Java",
+        stargazersCount = 200,
+        watchersCount = 200,
+        forksCount = 200,
+        openIssuesCount = 200,
+    ),
+    GithubRepositorySummary(
+        name = "dummy3",
+        ownerIconUrl = "https://dummy3.com",
+        language = "Swift",
+        stargazersCount = 300,
+        watchersCount = 300,
+        forksCount = 300,
+        openIssuesCount = 300,
+    ),
+    GithubRepositorySummary(
+        name = "dummy4",
+        ownerIconUrl = "https://dummy4.com",
+        language = "Objective-C",
+        stargazersCount = 400,
+        watchersCount = 400,
+        forksCount = 400,
+        openIssuesCount = 400,
+    ),
+    GithubRepositorySummary(
+        name = "dummy5",
+        ownerIconUrl = "https://dummy5.com",
+        language = "C++",
+        stargazersCount = 500,
+        watchersCount = 500,
+        forksCount = 500,
+        openIssuesCount = 500,
+    ),
+    GithubRepositorySummary(
+        name = "dummy6",
+        ownerIconUrl = "https://dummy6.com",
+        language = "C#",
+        stargazersCount = 600,
+        watchersCount = 600,
+        forksCount = 600,
+        openIssuesCount = 600,
+    ),
+    GithubRepositorySummary(
+        name = "dummy7",
+        ownerIconUrl = "https://dummy7.com",
+        language = "JavaScript",
+        stargazersCount = 700,
+        watchersCount = 700,
+        forksCount = 700,
+        openIssuesCount = 700,
+    ),
+    GithubRepositorySummary(
+        name = "dummy8",
+        ownerIconUrl = "https://dummy8.com",
+        language = "Go",
+        stargazersCount = 800,
+        watchersCount = 800,
+        forksCount = 800,
+        openIssuesCount = 800,
+    )
+)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/fake/FakeUserDataRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/data/fake/FakeUserDataRepository.kt
@@ -1,0 +1,18 @@
+package jp.co.yumemi.android.code_check.core.data.fake
+
+import jp.co.yumemi.android.code_check.core.data.UserDataRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.Date
+import javax.inject.Inject
+
+class FakeUserDataRepository @Inject constructor(): UserDataRepository {
+    private val _lastSearchDate: MutableStateFlow<Date?> = MutableStateFlow(null)
+    override val latestSearchDate: Flow<Date?>
+        get() = _lastSearchDate.asStateFlow()
+
+    override suspend fun saveLastSearchDate(date: Date) {
+        _lastSearchDate.value = date
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/testing/CodeCheckAppTestRunner.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/core/testing/CodeCheckAppTestRunner.kt
@@ -1,0 +1,12 @@
+package jp.co.yumemi.android.code_check.core.testing
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+class CodeCheckAppTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}


### PR DESCRIPTION
## 概要
- 検索 -> 検索結果をタップ -> レポジトリ情報を表示、するUIテストを実装
- Hiltを使用してFakeをDIするように実装

## 工夫した箇所
Androidテスト時もAPIにリクエストを送っていたので
- Fakeクラスを用意し、静的なデータを返すように。
- Fakeクラスをテスト時はHiltでDIするように
した

APIリクエストを行なっていると
- レスポンスを受け取るまでに時間がかかるため Sleepを入れる必要がある -> テストのパフォーマンスが下がる
- 実際のAPIにリクエストを送っているため、Rate Limit に達する可能性や、不要な下記がされてしまう
という可能性があるため、Fakeを利用するようにした

## 動作確認
### UIテスト実行時のキャプチャ
[Screen_recording_20240118_121619.webm](https://github.com/Ren-Toyokawa/android-engineer-codecheck/assets/23397943/2fec2565-b0d3-49ef-9894-f91f544caf41)

### テスト結果
<img width="1433" alt="スクリーンショット 2024-01-18 12 17 15" src="https://github.com/Ren-Toyokawa/android-engineer-codecheck/assets/23397943/5ff1e6e2-9eef-40e3-9ad6-35ee51edf638">
