### PR TITLE
CIからAndroidテストを除去

### DIFF
--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -3,7 +3,7 @@ name: Test
 on: [pull_request]
 
 jobs:
-  Build:
+  unitTest:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,44 +24,3 @@ jobs:
 
       - name: Run unit test on Debug Variant
         run: ./gradlew testDebugUnitTest
-
-  androidTest:
-    runs-on: macOS-latest # enables hardware acceleration in the virtual machine
-    timeout-minutes: 55
-    strategy:
-      matrix:
-        api-level: [ 26, 30 ]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 17
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Build projects before running emulator
-        run: ./gradlew packageDebug packageDebugAndroidTest
-
-      - name: Run instrumentation tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          arch: x86_64
-          disable-animations: true
-          profile: pixel_4_xl
-          disk-size: 6000M
-          heap-size: 600M
-          script: ./gradlew connectedDebugAndroidTest --daemon
-
-      - name: Upload test reports
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-reports-${{ matrix.api-level }}
-          path: '**/build/reports/androidTests'


### PR DESCRIPTION
## 概要
CIから androidTestを除去(時間がかかり過ぎてしまうため)
定期実行にするか、Firebase TestLabなどを使った方が良い