### PR TITLE
イシュー画面とイシュー画面への遷移処理を追加

### DIFF
--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/feature/RepositorySearchFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/feature/RepositorySearchFragmentTest.kt
@@ -61,5 +61,9 @@ class RepositorySearchFragmentTest {
 
         // RepositoryInfoFragmentのViewが表示されることを確認
         composeTestRule.onNodeWithTag("RepositoryInfoScreen").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("IssueButton").performClick()
+
+        composeTestRule.onNodeWithTag("RepositoryIssueScreen").assertIsDisplayed()
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/info/RepositoryInfoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/info/RepositoryInfoFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.R
@@ -42,7 +43,8 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
             setContent {
                 CodeCheckAppTheme {
                     RepositoryInfoRoute(
-                        repositorySummary = args.githubRepositorySummary
+                        repositorySummary = args.githubRepositorySummary,
+                        navigateRepositoryIssueFragment = ::navigateToRepositoryIssueFragment
                     )
                 }
             }
@@ -67,5 +69,13 @@ class RepositoryInfoFragment : Fragment(R.layout.fragment_repository_info) {
             val lastSearchDate = userDataRepository.latestSearchDate.first()
             Log.d(TAG, "検索した日時: $lastSearchDate")
         }
+    }
+
+    private fun navigateToRepositoryIssueFragment() {
+        val action =
+            RepositoryInfoFragmentDirections.actionRepositoryInfoFragmentToRepositoryIssueFragment(
+            )
+
+        findNavController().navigate(action)
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/info/RepositoryInfoHeader.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/info/RepositoryInfoHeader.kt
@@ -3,6 +3,7 @@ package jp.co.yumemi.android.code_check.feature.repository.info
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -32,7 +34,8 @@ import jp.co.yumemi.android.code_check.core.ui.component.toKString
 
 @Composable
 fun RepositoryInfoHeader(
-    repositorySummary: GithubRepositorySummary
+    repositorySummary: GithubRepositorySummary,
+    onTapIssue: () -> Unit
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -42,7 +45,8 @@ fun RepositoryInfoHeader(
         )
 
         RepositoryBasicData(
-            repositorySummary = repositorySummary
+            repositorySummary = repositorySummary,
+            onTapIssue = onTapIssue,
         )
 
         RepositoryWrittenLanguage(
@@ -78,7 +82,8 @@ fun RepositoryNameAndIcon(
 
 @Composable
 fun RepositoryBasicData(
-    repositorySummary: GithubRepositorySummary
+    repositorySummary: GithubRepositorySummary,
+    onTapIssue: () -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -103,6 +108,11 @@ fun RepositoryBasicData(
         )
 
         IconWithCount(
+            modifier = Modifier
+                .clickable {
+                    onTapIssue()
+                }
+                .testTag("IssueButton"),
             iconPainterResource = painterResource(id = R.drawable.issue_opened),
             count = repositorySummary.openIssuesCount
         )
@@ -172,7 +182,8 @@ fun RepositoryWrittenLanguage(
 fun RepositoryInfoHeaderPreview() {
     CodeCheckAppTheme {
         RepositoryInfoHeader(
-            repositorySummary = dummySearchResults[0]
+            repositorySummary = dummySearchResults[0],
+            onTapIssue = {}
         )
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/info/RepositoryInfoScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/info/RepositoryInfoScreen.kt
@@ -19,16 +19,19 @@ import jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary
 @Composable
 fun RepositoryInfoRoute(
     repositorySummary: GithubRepositorySummary,
+    navigateRepositoryIssueFragment: () -> Unit
 ) {
     RepositoryInfoScreen(
-        repositorySummary = repositorySummary
+        repositorySummary = repositorySummary,
+        onTapIssue = navigateRepositoryIssueFragment
     )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RepositoryInfoScreen(
-    repositorySummary: GithubRepositorySummary
+    repositorySummary: GithubRepositorySummary,
+    onTapIssue: () -> Unit
 ) {
     val scrollState = rememberScrollState()
 
@@ -43,7 +46,8 @@ fun RepositoryInfoScreen(
                 .padding(8.dp),
         ) {
             RepositoryInfoHeader(
-                repositorySummary = repositorySummary
+                repositorySummary = repositorySummary,
+                onTapIssue = onTapIssue
             )
         }
     }
@@ -55,7 +59,8 @@ fun RepositoryInfoScreen(
 fun RepositoryInfoScreenPreview() {
     CodeCheckAppTheme {
         RepositoryInfoScreen(
-            repositorySummary = dummySearchResults[0]
+            repositorySummary = dummySearchResults[0],
+            onTapIssue = {}
         )
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/issue/RepositoryIssueFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/issue/RepositoryIssueFragment.kt
@@ -1,0 +1,27 @@
+package jp.co.yumemi.android.code_check.feature.repository.issue
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material3.Text
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import jp.co.yumemi.android.code_check.core.designsystem.theme.CodeCheckAppTheme
+import jp.co.yumemi.android.code_check.feature.repository.info.RepositoryInfoRoute
+
+class RepositoryIssueFragment: Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                CodeCheckAppTheme {
+                    RepositoryIssueRoute()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/issue/RepositoryIssueScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/feature/repository/issue/RepositoryIssueScreen.kt
@@ -1,0 +1,42 @@
+package jp.co.yumemi.android.code_check.feature.repository.issue
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun RepositoryIssueRoute(
+    modifier: Modifier = Modifier
+) {
+    RepositoryIssueScreen()
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RepositoryIssueScreen(
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = Modifier.testTag("RepositoryIssueScreen")
+    ) {
+        Column(
+            modifier = Modifier.padding(it)
+        ) {
+            Text(
+                text = "RepositoryIssueScreen"
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun RepositoryIssueScreenPreview() {
+    RepositoryIssueScreen()
+}

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -23,6 +23,15 @@
         <argument
             android:name="githubRepositorySummary"
             app:argType="jp.co.yumemi.android.code_check.core.model.GithubRepositorySummary" />
+        <action
+            android:id="@+id/action_repositoryInfoFragment_to_repositoryIssueFragment"
+            app:destination="@id/repositoryIssueFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/repositoryIssueFragment"
+        android:name="jp.co.yumemi.android.code_check.feature.repository.issue.RepositoryIssueFragment"
+        android:label="@string/repository_issue">
     </fragment>
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Android Engineer CodeCheck</string>
     <string name="repositories_search">レポジトリ検索</string>
     <string name="repository_info">レポジトリ情報</string>
+    <string name="repository_issue">レポジトリのissue</string>
     <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
     <string name="written_language">Written in %s</string>
     <string name="language_not_specified">言語は設定されていません</string>


### PR DESCRIPTION
## 概要
- イシュー画面を追加
- イシュー画面への遷移を追加
- イシュー画面への遷移のテストを追加

## 工夫した箇所
テストファーストで実装した
画面遷移がテストで失敗 ->　実装を修正 -> テストが成功するように実装した

## 動作確認
UIテストが成功することを確認